### PR TITLE
chore(browser): add types tests

### DIFF
--- a/lib/browser/browser.spec-int.ts
+++ b/lib/browser/browser.spec-int.ts
@@ -1,7 +1,7 @@
 import * as log from 'loglevel';
 import * as wdm from 'webdriver-manager-replacement';
 import {Browser} from './browser';
-import {requestBody} from '../spec/support/http_utils';
+import {requestBody} from '../../spec/support/http_utils';
 
 log.setLevel('info');
 

--- a/lib/browser/browser.spec-types.ts
+++ b/lib/browser/browser.spec-types.ts
@@ -1,0 +1,69 @@
+import {Session, WebDriver} from 'selenium-webdriver';
+const Executor = require('selenium-webdriver/lib/command').Executor;
+import * as log from 'loglevel';
+
+log.setLevel('debug');
+
+function getWebDriver() {
+  const session = '1234';
+  const capabilities = {
+    browserName: 'chrome'
+  };
+  return new WebDriver(
+    new Session(session, capabilities),
+    new Executor());
+};
+
+const WEBDRIVER = {
+  staticFunctions: [
+    'createSession',
+  ],
+
+  instanceFunctions: [
+    'actions',
+    'close',
+    'executeAsyncScript',
+    'findElement',
+    'findElements', 
+    'get',
+    'getAllWindowHandles',
+    'getCapabilities',
+    'getCurrentUrl',
+    'getPageSource',
+    'getSession',
+    'getTitle',
+    'getWindowHandle',
+    'manage',
+    'navigate',
+    'quit',
+    'sleep',
+    'switchTo',
+    'takeScreenshot',
+    'wait',
+  ],
+};
+
+describe('browser', () => {
+  describe('driver', () => {
+    it('should have a static functions', () => {
+      for (const pos in WEBDRIVER.staticFunctions) {
+        const staticFunc = WEBDRIVER.staticFunctions[pos];
+        if (typeof WebDriver[staticFunc] !== 'function') {
+          log.error(`requires review: ${staticFunc}`);
+        }
+        expect(typeof WebDriver[staticFunc] === 'function').toBe(true);
+      }
+    });
+  
+    it('should have instance functions', () => {
+      const webdriver = getWebDriver();
+      for (const pos in WEBDRIVER.instanceFunctions) {
+        const instanceFunc = WEBDRIVER.instanceFunctions[pos];
+        if (typeof webdriver[instanceFunc] !== 'function') {
+          log.error(`requires review: ${instanceFunc}`);
+        }
+        expect(typeof webdriver[instanceFunc] == 'function').toBe(true);
+      }
+    });
+  });
+});

--- a/lib/browser/browser.ts
+++ b/lib/browser/browser.ts
@@ -1,10 +1,11 @@
 import {Builder, WebDriver, Session} from 'selenium-webdriver';
-import {wait} from './wait';
+import {wait} from '../wait';
 
 export class Browser {
   seleniumAddress = 'http://127.0.0.1:4444/wd/hub';
   driver: WebDriver;
   session: Session;
+
   // TODO(cnishina): implement later?
   rootEl: any;
 

--- a/lib/browser/index.ts
+++ b/lib/browser/index.ts
@@ -1,0 +1,1 @@
+export * from './browser';

--- a/lib/by/webdriver_by.spec-types.ts
+++ b/lib/by/webdriver_by.spec-types.ts
@@ -1,4 +1,7 @@
 import {By} from 'selenium-webdriver';
+import * as log from 'loglevel';
+
+log.setLevel('debug');
 
 const BY = {
   staticFunctions: [
@@ -17,7 +20,10 @@ describe('webdriver_by', () => {
   it('should have a static functions', () => {
     for (const pos in BY.staticFunctions) {
       const func = BY.staticFunctions[pos];
-      expect(typeof By[func] == 'function').toBe(true);
+      if (typeof By[func] !== 'function') {
+        log.error(`requires review: ${func}`);
+      }
+      expect(typeof By[func] === 'function').toBe(true);
     }
   });
 });


### PR DESCRIPTION
- move browser files to a browser folder
- selenium-webdriver@4 removes static method: attachToSession
alternatively, refer to
https://github.com/angular/protractor/issues/4557 and https://github.com/SeleniumHQ/selenium/commit/e94377966f92c90af93dfd75b4e10ca6c9055271#commitcomment-28181671
- selenium-webdriver@4 removes instance methods: call, touchActions