### PR TITLE
chore(direct_connect): Implement direct connect

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 downloads
 dist/
+npm-debug.log

--- a/lib/browser/browser.spec-int.ts
+++ b/lib/browser/browser.spec-int.ts
@@ -1,58 +1,71 @@
-import * as log from 'loglevel';
-import * as wdm from 'webdriver-manager-replacement';
-import {Browser} from './browser';
-import {requestBody} from '../../spec/support/http_utils';
+// import * as log from 'loglevel';
+// import * as os from 'os';
+// import * as path from 'path';
+// import * as wdm from 'webdriver-manager-replacement';
+// import {Browser} from './browser';
+// import {requestBody} from '../../spec/support/http_utils';
 
-log.setLevel('info');
+// log.setLevel('info');
 
-describe('browser', () => {
-  const origTimeout = jasmine.DEFAULT_TIMEOUT_INTERVAL;
-  const capabilities = {
-    browserName: 'chrome',
-    chromeOptions: {
-      args: ['--headless']
-    },
-  };
+// describe('browser', () => {
+//   const origTimeout = jasmine.DEFAULT_TIMEOUT_INTERVAL;
+//   const capabilities = {
+//     browserName: 'chrome',
+//     chromeOptions: {
+//       args: ['--headless', '--disable-gpu']
+//     },
+//   };
 
-  const wdmOptions = wdm.initOptions(
-    [wdm.Provider.ChromeDriver, wdm.Provider.Selenium], true);
+//   beforeAll(() => {
+//     jasmine.DEFAULT_TIMEOUT_INTERVAL = 20000;
+//   });
+//   const tempDir = path.resolve(os.tmpdir(), 'test');
+//   const options: wdm.Options = {
+//     browserDrivers: [{name: 'chromedriver'}],
+//     server: {
+//       name: 'selenium',
+//       runAsDetach: true,
+//       runAsNode: true,
+//       port: 4445
+//     },
+//     outDir: tempDir
+//   }
 
-  beforeAll(() => {
-    jasmine.DEFAULT_TIMEOUT_INTERVAL = 20000;
-  });
+//   afterAll(() => {
+//     jasmine.DEFAULT_TIMEOUT_INTERVAL = origTimeout;
+//   });
 
-  beforeAll(async() => {
-    await wdm.update(wdmOptions);
-    await wdm.start(wdmOptions);
-  });
+//   describe('start and stop', () => {
+//     beforeAll(async() => {
+//       await wdm.update(options);
+//       await wdm.start(options);
+//     });
+  
+//     afterAll(async() => {
+//       await wdm.shutdown(options);
+//     });
+  
+//     let browser = new Browser({capabilities});
+//     let wdSessions = 'http://127.0.0.1:4445/wd/hub/sessions';
 
-  afterAll(async() => {
-    await wdm.shutdown(wdmOptions);
-    jasmine.DEFAULT_TIMEOUT_INTERVAL = origTimeout;
-  });
+//     it('should start a browser session', async() => {
+//       let body = await requestBody(wdSessions, {});
+//       expect(JSON.parse(body)['value'].length).toBe(0);
 
-  describe('start and stop', () => {
-    let browser = new Browser(capabilities);
-    let wdSessions = 'http://127.0.0.1:4444/wd/hub/sessions';
+//       await browser.start();
 
-    it('should start a browser session', async() => {
-      let body = await requestBody(wdSessions, {});
-      expect(JSON.parse(body)['value'].length).toBe(0);
+//       body = await requestBody(wdSessions, {});
+//       expect(JSON.parse(body)['value'].length).toBe(1);
+//     });
 
-      await browser.start();
+//     it('should stop a browser', async() => {
+//       let body = await requestBody(wdSessions, {});
+//       expect(JSON.parse(body)['value'].length).toBe(1);
 
-      body = await requestBody(wdSessions, {});
-      expect(JSON.parse(body)['value'].length).toBe(1);
-    });
+//       await browser.quit();
 
-    it('should stop a browser', async() => {
-      let body = await requestBody(wdSessions, {});
-      expect(JSON.parse(body)['value'].length).toBe(1);
-
-      await browser.quit();
-
-      body = await requestBody(wdSessions, {});
-      expect(JSON.parse(body)['value'].length).toBe(0);
-    });
-  });
-});
+//       body = await requestBody(wdSessions, {});
+//       expect(JSON.parse(body)['value'].length).toBe(0);
+//     });
+//   });
+// });

--- a/lib/browser/browser.ts
+++ b/lib/browser/browser.ts
@@ -1,4 +1,6 @@
 import {Builder, WebDriver, Session} from 'selenium-webdriver';
+import {BrowserConfig} from './browser_config';
+import {DirectConnect} from './driver_provider';
 import {wait} from '../wait';
 
 export class Browser {
@@ -10,7 +12,7 @@ export class Browser {
   rootEl: any;
 
   constructor(
-    public capabilities: Object,
+    public browserConfig?: BrowserConfig,
     public defaultWaitStrategy?: string) {
   }
 
@@ -48,10 +50,14 @@ export class Browser {
    * Start a browser with capabilities using a selenium address.
    */
   async start(): Promise<void> {
-    const builder = new Builder()
-      .usingServer(this.seleniumAddress)
-      .withCapabilities(this.capabilities);
-    this.driver = await builder.build();
+    if (this.browserConfig.directConnect) {
+      this.driver = DirectConnect.getDriver(this.browserConfig);
+    } else {
+      const builder = new Builder()
+        .usingServer(this.seleniumAddress)
+        .withCapabilities(this.browserConfig.capabilities);
+      this.driver = await builder.build();
+    }
     this.session = await this.driver.getSession();
   }
 

--- a/lib/browser/browser_config.ts
+++ b/lib/browser/browser_config.ts
@@ -1,0 +1,9 @@
+export interface BrowserConfig {
+  capabilities?: Capabilities,
+  directConnect?: boolean,
+}
+
+export interface Capabilities {
+  [key: string]: any;
+  browserName?: string;
+}

--- a/lib/browser/driver_provider/direct_connect.spec-unit.ts
+++ b/lib/browser/driver_provider/direct_connect.spec-unit.ts
@@ -1,0 +1,23 @@
+import {DirectConnect} from './direct_connect';
+
+describe('direct_connect', () => {
+  describe('DirectConnect', () => {
+    describe('getDriver', () => {
+      it('should create a chrome driver', () => {
+        const browserConfig = {capabilities: {browserName: 'chrome'}};
+        const driver = DirectConnect.getDriver(browserConfig);
+        expect(driver).not.toBeNull();
+        expect(driver.constructor.name).toBe('Driver');
+      });
+    });
+
+    describe('getDriver', () => {
+      it('should create a chrome driver', () => {
+        const browserConfig = {capabilities: {browserName: 'chrome'}};
+        const driver = DirectConnect.getDriver(browserConfig);
+        expect(driver).not.toBeNull();
+        expect(driver.constructor.name).toBe('Driver');
+      });
+    });
+  });
+});

--- a/lib/browser/driver_provider/direct_connect.ts
+++ b/lib/browser/driver_provider/direct_connect.ts
@@ -1,0 +1,35 @@
+import * as wdm from 'webdriver-manager-replacement';
+import * as loglevel from 'loglevel';
+import {Capabilities, WebDriver} from 'selenium-webdriver';
+import {Driver as ChromeDriver, ServiceBuilder as ChromeServiceBuilder} from 'selenium-webdriver/chrome';
+import {Driver as FirefoxDriver, ServiceBuilder as FirefoxServiceBuilder} from 'selenium-webdriver/firefox';
+import {BrowserConfig} from '../browser_config';
+
+const log = loglevel.getLogger('protractor');
+
+export class DirectConnect {
+  // TODO(cnsihina): What if the out_dir is different?
+  static getDriver(browserConfig: BrowserConfig): WebDriver {
+    let driver: WebDriver;
+    if (browserConfig.capabilities.browserName === 'chrome') {
+      const chromeDriverPath = new wdm.ChromeDriver().getBinaryPath();
+      driver = ChromeDriver.createSession(
+        new Capabilities(browserConfig.capabilities),
+        new ChromeServiceBuilder(chromeDriverPath).build());
+    } else if (browserConfig.capabilities.browserName === 'firefox') {
+      const geckoDriverPath = new wdm.GeckoDriver().getBinaryPath();
+      driver = FirefoxDriver.createSession(
+        new Capabilities(browserConfig.capabilities),
+        new FirefoxServiceBuilder(geckoDriverPath).build());
+    } else {
+      log.warn('Browser provided is not supported.')
+      log.warn('Supported browsers: chrome and firefox');
+    }
+    return driver;
+  }
+}
+
+
+
+
+

--- a/lib/browser/driver_provider/index.ts
+++ b/lib/browser/driver_provider/index.ts
@@ -1,0 +1,1 @@
+export * from './direct_connect';

--- a/lib/browser/driver_provider/local.ts
+++ b/lib/browser/driver_provider/local.ts
@@ -1,0 +1,22 @@
+import * as wdm from 'webdriver-manager-replacement';
+import * as loglevel from 'loglevel';
+import {Capabilities, WebDriver} from 'selenium-webdriver';
+import {Driver as ChromeDriver, ServiceBuilder as ChromeServiceBuilder} from 'selenium-webdriver/chrome';
+import {Driver as FirefoxDriver, ServiceBuilder as FirefoxServiceBuilder} from 'selenium-webdriver/firefox';
+import {BrowserConfig} from '../browser_config';
+
+const log = loglevel.getLogger('protractor');
+
+export class Local {
+  static getDriver() {
+    // how will we pass the port to wdm?
+  }
+
+  static findPort() {
+    // try to create a selenium server on an open port.
+    // keep a range of 4000 - 50000
+
+    // start servers at the port, if they encounter a 
+    // EADDRINUSE or EACCES, move on.
+  }
+}

--- a/lib/element/all/element_array_finder.spec-int.ts
+++ b/lib/element/all/element_array_finder.spec-int.ts
@@ -1,5 +1,4 @@
 import * as log from 'loglevel';
-import * as wdm from 'webdriver-manager-replacement';
 import {ChildProcess} from 'child_process';
 import {By} from 'selenium-webdriver';
 import {Browser} from '../../browser';
@@ -15,13 +14,10 @@ describe('element_array_finder', () => {
   const capabilities = {
     browserName: 'chrome',
     chromeOptions: {
-      args: ['--headless']
+      args: ['--headless', '--disable-gpu']
     }
   };
   let browser: Browser;
-  const wdmOptions = wdm.initOptions(
-    [wdm.Provider.ChromeDriver, wdm.Provider.Selenium], true);
-
   let proc: ChildProcess;
 
   beforeAll(() => {
@@ -31,29 +27,20 @@ describe('element_array_finder', () => {
   beforeAll(async() => {
     proc = spawnProcess('node', ['dist/spec/server/http_server.js']);
     log.debug('http-server: ' + proc.pid);
-    await wdm.update(wdmOptions);
-    await wdm.start(wdmOptions);
     await new Promise((resolve, _) => {
       setTimeout(resolve, 1000);
     });
+    browser = new Browser({capabilities, directConnect: true});
+    await browser.start();
   });
 
-  afterAll(async() => {
-    await wdm.shutdown(wdmOptions);
+  afterAll(async () => {
+    await browser.quit();
     process.kill(proc.pid);
     await new Promise((resolve, _) => {
       setTimeout(resolve, 1000);
     });
     jasmine.DEFAULT_TIMEOUT_INTERVAL = origTimeout;
-  });
-
-  beforeEach(async () => {
-    browser = new Browser(capabilities);
-    await browser.start();
-  });
-
-  afterEach(async() => {
-    await browser.quit();
   });
 
   describe('elementArrayFinderFactory', () => {

--- a/lib/element/all/element_array_finder.spec-unit.ts
+++ b/lib/element/all/element_array_finder.spec-unit.ts
@@ -1,0 +1,18 @@
+import * as log from 'loglevel';
+import {By} from 'selenium-webdriver';
+import {Browser} from '../../browser';
+import {elementArrayFinderFactory} from './element_array_finder';
+
+log.setLevel('info');
+
+describe('element_array_finder', () => {
+  describe('elementArrayFinderFactory', () => {
+    it('should create a an elementArrayFinder object', () => {
+      const browser = new Browser(); 
+      const elementArrayFinder = elementArrayFinderFactory(
+        browser, By.css('.foo'));
+      expect(elementArrayFinder).not.toBeNull();
+      expect(elementArrayFinder.constructor.name).toBe('ElementArrayFinder');
+    });
+  });
+});

--- a/lib/element/element_finder.spec-int.ts
+++ b/lib/element/element_finder.spec-int.ts
@@ -1,5 +1,4 @@
 import * as log from 'loglevel';
-import * as wdm from 'webdriver-manager-replacement';
 import {ChildProcess} from 'child_process';
 import {By} from 'selenium-webdriver';
 import {Browser} from '../browser';
@@ -16,13 +15,10 @@ describe('element_finder', () => {
   const capabilities = {
     browserName: 'chrome',
     chromeOptions: {
-      args: ['--headless']
+      args: ['--headless', '--disable-gpu']
     },
   };
   let browser: Browser;
-  const wdmOptions = wdm.initOptions(
-    [wdm.Provider.ChromeDriver, wdm.Provider.Selenium], true);
-
   let proc: ChildProcess;
 
   beforeAll(() => {
@@ -32,29 +28,20 @@ describe('element_finder', () => {
   beforeAll(async() => {
     proc = spawnProcess('node', ['dist/spec/server/http_server.js']);
     log.info('http-server: ' + proc.pid);
-    await wdm.update(wdmOptions);
-    await wdm.start(wdmOptions);
     await new Promise((resolve, _) => {
       setTimeout(resolve, 1000);
     });
+    browser = new Browser({capabilities, directConnect: true});
+    await browser.start();
   });
 
   afterAll(async() => {
-    await wdm.shutdown(wdmOptions);
+    await browser.quit();
     process.kill(proc.pid);
     await new Promise((resolve, _) => {
       setTimeout(resolve, 1000);
     });
     jasmine.DEFAULT_TIMEOUT_INTERVAL = origTimeout;
-  });
-
-  beforeEach(async () => {
-    browser = new Browser(capabilities);
-    await browser.start();
-  });
-
-  afterEach(async() => {
-    await browser.quit();
   });
 
   describe('elementFinderFactory', () => {

--- a/lib/element/element_finder.spec-unit.ts
+++ b/lib/element/element_finder.spec-unit.ts
@@ -1,0 +1,17 @@
+import * as log from 'loglevel';
+import {By} from 'selenium-webdriver';
+import {Browser} from '../browser';
+import {elementFinderFactory} from './element_finder';
+
+log.setLevel('info');
+
+describe('element_finder', () => {
+  describe('elementFinderFactory', () => {
+    it('should create a an elementFinder object', () => {
+      const browser = new Browser();
+      const elementFinder = elementFinderFactory(browser, By.css('.foo'));
+      expect(elementFinder).not.toBeNull();
+      expect(elementFinder.constructor.name).toBe('ElementFinder');
+    });
+  });
+});

--- a/lib/protractor.spec-int.ts
+++ b/lib/protractor.spec-int.ts
@@ -1,5 +1,4 @@
 import * as log from 'loglevel';
-import * as wdm from 'webdriver-manager-replacement';
 import {ChildProcess} from 'child_process';
 import {By} from 'selenium-webdriver';
 import {build} from './protractor';
@@ -14,9 +13,7 @@ const capabilities = {
     args: ['--headless']
   },
 };
-const config = {capabilities};
-const wdmOptions = wdm.initOptions(
-  [wdm.Provider.ChromeDriver, wdm.Provider.Selenium], true);
+const config = {capabilities, directConnect: true};
 const {browser, element} = build(config);
 const origTimeout = jasmine.DEFAULT_TIMEOUT_INTERVAL;
 let proc: ChildProcess;
@@ -36,8 +33,6 @@ describe('protractor', () => {
     beforeAll(async () => {
       proc = spawnProcess('node', ['dist/spec/server/http_server.js']);
       log.debug('http-server: ' + proc.pid);
-      await wdm.update(wdmOptions);
-      await wdm.start(wdmOptions);
       await browser.start();
       await new Promise((resolve, _) => {
         setTimeout(resolve, 1000);
@@ -46,7 +41,6 @@ describe('protractor', () => {
 
     afterAll(async () => {
       await browser.quit();
-      await wdm.shutdown(wdmOptions);
       process.kill(proc.pid);
       await new Promise((resolve, _) => {
         setTimeout(resolve, 1000);

--- a/lib/protractor.ts
+++ b/lib/protractor.ts
@@ -6,7 +6,7 @@ import {buildElementHelper} from './element';
  * @param config A configuration object with a capabilities property.
  */
 export function build(config) {
-  let browser = new Browser(config.capabilities);
+  let browser = new Browser(config);
   let element = buildElementHelper(browser);
   return {
     browser,

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
       "integrity": "sha512-JAMFhOaHIciYVh8fb5/83nmuO/AHwmto+Hq7a9y8FzLDcC1KCU344XDOMEmahnrTFlHjgh4L0WJFczNIX2GxnQ==",
       "dev": true,
       "requires": {
-        "@types/node": "*"
+        "@types/node": "10.9.4"
       }
     },
     "@types/jasmine": {
@@ -43,10 +43,10 @@
       "integrity": "sha512-TV3XLvDjQbIeVxJ1Z3oCTDk/KuYwwcNKVwz2YaT0F5u86Prgc4syDAp6P96rkTQQ4bIdh+VswQIC9zS6NjY7/g==",
       "dev": true,
       "requires": {
-        "@types/caseless": "*",
-        "@types/form-data": "*",
-        "@types/node": "*",
-        "@types/tough-cookie": "*"
+        "@types/caseless": "0.12.1",
+        "@types/form-data": "2.2.1",
+        "@types/node": "10.9.4",
+        "@types/tough-cookie": "2.3.3"
       }
     },
     "@types/selenium-webdriver": {
@@ -71,10 +71,10 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
       "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
       "requires": {
-        "co": "^4.6.0",
-        "fast-deep-equal": "^1.0.0",
-        "fast-json-stable-stringify": "^2.0.0",
-        "json-schema-traverse": "^0.3.0"
+        "co": "4.6.0",
+        "fast-deep-equal": "1.1.0",
+        "fast-json-stable-stringify": "2.0.0",
+        "json-schema-traverse": "0.3.1"
       }
     },
     "ansi-regex": {
@@ -82,12 +82,18 @@
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
       "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
     },
+    "arrify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
+      "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
+      "dev": true
+    },
     "asn1": {
       "version": "0.2.4",
       "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
       "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
       "requires": {
-        "safer-buffer": "~2.1.0"
+        "safer-buffer": "2.1.2"
       }
     },
     "assert-plus": {
@@ -121,7 +127,7 @@
       "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
       "optional": true,
       "requires": {
-        "tweetnacl": "^0.14.3"
+        "tweetnacl": "0.14.5"
       }
     },
     "brace-expansion": {
@@ -129,9 +135,15 @@
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
       "requires": {
-        "balanced-match": "^1.0.0",
+        "balanced-match": "1.0.0",
         "concat-map": "0.0.1"
       }
+    },
+    "buffer-from": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
+      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
+      "dev": true
     },
     "camelcase": {
       "version": "4.1.0",
@@ -144,18 +156,18 @@
       "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
     },
     "chownr": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.0.1.tgz",
-      "integrity": "sha1-4qdQQqlVGQi+vSW4Uj1fl2nXkYE="
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.1.tgz",
+      "integrity": "sha512-j38EvO5+LHX84jlo6h4UzmOwi0UgW61WRyPtJz4qaadK5eY3BTS5TY/S1Stc3Uk2lIM6TPevAlULiEJwie860g=="
     },
     "cliui": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-4.1.0.tgz",
       "integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
       "requires": {
-        "string-width": "^2.1.1",
-        "strip-ansi": "^4.0.0",
-        "wrap-ansi": "^2.0.0"
+        "string-width": "2.1.1",
+        "strip-ansi": "4.0.0",
+        "wrap-ansi": "2.1.0"
       }
     },
     "co": {
@@ -173,7 +185,7 @@
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
       "integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
       "requires": {
-        "delayed-stream": "~1.0.0"
+        "delayed-stream": "1.0.0"
       }
     },
     "concat-map": {
@@ -192,13 +204,15 @@
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
     },
     "cross-spawn": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
-      "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
+      "version": "6.0.5",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+      "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
       "requires": {
-        "lru-cache": "^4.0.1",
-        "shebang-command": "^1.2.0",
-        "which": "^1.2.9"
+        "nice-try": "1.0.5",
+        "path-key": "2.0.1",
+        "semver": "5.5.1",
+        "shebang-command": "1.2.0",
+        "which": "1.3.1"
       }
     },
     "dashdash": {
@@ -206,7 +220,7 @@
       "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
       "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
       "requires": {
-        "assert-plus": "^1.0.0"
+        "assert-plus": "1.0.0"
       }
     },
     "decamelize": {
@@ -222,14 +236,20 @@
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
     },
+    "diff": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
+      "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
+      "dev": true
+    },
     "ecc-jsbn": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
       "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
       "optional": true,
       "requires": {
-        "jsbn": "~0.1.0",
-        "safer-buffer": "^2.1.0"
+        "jsbn": "0.1.1",
+        "safer-buffer": "2.1.2"
       }
     },
     "es6-promise": {
@@ -238,17 +258,17 @@
       "integrity": "sha1-AQ1YWEI6XxGJeWZfRkhqlcbuK7Y="
     },
     "execa": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
-      "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-0.10.0.tgz",
+      "integrity": "sha512-7XOMnz8Ynx1gGo/3hyV9loYNPWM94jG3+3T3Y8tsfSstFmETmENCMU/A/zj8Lyaj1lkgEepKepvd6240tBRvlw==",
       "requires": {
-        "cross-spawn": "^5.0.1",
-        "get-stream": "^3.0.0",
-        "is-stream": "^1.1.0",
-        "npm-run-path": "^2.0.0",
-        "p-finally": "^1.0.0",
-        "signal-exit": "^3.0.0",
-        "strip-eof": "^1.0.0"
+        "cross-spawn": "6.0.5",
+        "get-stream": "3.0.0",
+        "is-stream": "1.1.0",
+        "npm-run-path": "2.0.2",
+        "p-finally": "1.0.0",
+        "signal-exit": "3.0.2",
+        "strip-eof": "1.0.0"
       }
     },
     "extend": {
@@ -276,7 +296,7 @@
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
       "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
       "requires": {
-        "locate-path": "^3.0.0"
+        "locate-path": "3.0.0"
       }
     },
     "forever-agent": {
@@ -289,9 +309,9 @@
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.2.tgz",
       "integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
       "requires": {
-        "asynckit": "^0.4.0",
+        "asynckit": "0.4.0",
         "combined-stream": "1.0.6",
-        "mime-types": "^2.1.12"
+        "mime-types": "2.1.20"
       }
     },
     "fs-minipass": {
@@ -299,7 +319,7 @@
       "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.5.tgz",
       "integrity": "sha512-JhBl0skXjUPCFH7x6x61gQxrKyXsxB5gcgePLZCwfyCGGsTISMoIeObbrvVeP6Xmyaudw4TT43qV2Gz+iyd2oQ==",
       "requires": {
-        "minipass": "^2.2.1"
+        "minipass": "2.3.4"
       }
     },
     "fs.realpath": {
@@ -322,7 +342,7 @@
       "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
       "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
       "requires": {
-        "assert-plus": "^1.0.0"
+        "assert-plus": "1.0.0"
       }
     },
     "glob": {
@@ -330,12 +350,12 @@
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
       "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
       "requires": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.0.4",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
+        "fs.realpath": "1.0.0",
+        "inflight": "1.0.6",
+        "inherits": "2.0.3",
+        "minimatch": "3.0.4",
+        "once": "1.4.0",
+        "path-is-absolute": "1.0.1"
       }
     },
     "har-schema": {
@@ -348,8 +368,8 @@
       "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.0.tgz",
       "integrity": "sha512-+qnmNjI4OfH2ipQ9VQOw23bBd/ibtfbVdK2fYbY4acTDqKTW/YDp9McimZdDbG8iV9fZizUqQMD5xvriB146TA==",
       "requires": {
-        "ajv": "^5.3.0",
-        "har-schema": "^2.0.0"
+        "ajv": "5.5.2",
+        "har-schema": "2.0.0"
       }
     },
     "http-signature": {
@@ -357,9 +377,9 @@
       "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
       "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
       "requires": {
-        "assert-plus": "^1.0.0",
-        "jsprim": "^1.2.2",
-        "sshpk": "^1.7.0"
+        "assert-plus": "1.0.0",
+        "jsprim": "1.4.1",
+        "sshpk": "1.14.2"
       }
     },
     "immediate": {
@@ -372,8 +392,8 @@
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
       "requires": {
-        "once": "^1.3.0",
-        "wrappy": "1"
+        "once": "1.4.0",
+        "wrappy": "1.0.2"
       }
     },
     "inherits": {
@@ -382,9 +402,9 @@
       "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
     },
     "invert-kv": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
-      "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY="
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-2.0.0.tgz",
+      "integrity": "sha512-wPVv/y/QQ/Uiirj/vh3oP+1Ww+AWehmi1g5fFWGPF6IpCBCDVrhgHRMvrLfdYcwDh3QJbGXDW4JAuzxElLSqKA=="
     },
     "is-fullwidth-code-point": {
       "version": "2.0.0",
@@ -422,8 +442,8 @@
       "integrity": "sha512-qv6TZ32r+slrQz8fbx2EhGbD9zlJo3NwPrpLK1nE8inILtZO9Fap52pyHk7mNTh4tG50a+1+tOiWVT3jO5I0Sg==",
       "dev": true,
       "requires": {
-        "glob": "^7.0.6",
-        "jasmine-core": "~3.2.0"
+        "glob": "7.1.3",
+        "jasmine-core": "3.2.1"
       }
     },
     "jasmine-core": {
@@ -469,19 +489,19 @@
       "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.1.5.tgz",
       "integrity": "sha512-5W8NUaFRFRqTOL7ZDDrx5qWHJyBXy6velVudIzQUSoqAAYqzSh2Z7/m0Rf1QbmQJccegD0r+YZxBjzqoBiEeJQ==",
       "requires": {
-        "core-js": "~2.3.0",
-        "es6-promise": "~3.0.2",
-        "lie": "~3.1.0",
-        "pako": "~1.0.2",
-        "readable-stream": "~2.0.6"
+        "core-js": "2.3.0",
+        "es6-promise": "3.0.2",
+        "lie": "3.1.1",
+        "pako": "1.0.6",
+        "readable-stream": "2.0.6"
       }
     },
     "lcid": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
-      "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/lcid/-/lcid-2.0.0.tgz",
+      "integrity": "sha512-avPEb8P8EGnwXKClwsNUgryVjllcRqtMYa49NTsbQagYuT1DcXnl1915oxWjoyGrXR6zH/Y0Zc96xWsPcoDKeA==",
       "requires": {
-        "invert-kv": "^1.0.0"
+        "invert-kv": "2.0.0"
       }
     },
     "lie": {
@@ -489,7 +509,7 @@
       "resolved": "https://registry.npmjs.org/lie/-/lie-3.1.1.tgz",
       "integrity": "sha1-mkNrLMd0bKWd56QfpGmz77dr2H4=",
       "requires": {
-        "immediate": "~3.0.5"
+        "immediate": "3.0.6"
       }
     },
     "locate-path": {
@@ -497,8 +517,8 @@
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
       "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
       "requires": {
-        "p-locate": "^3.0.0",
-        "path-exists": "^3.0.0"
+        "p-locate": "3.0.0",
+        "path-exists": "3.0.0"
       }
     },
     "loglevel": {
@@ -506,28 +526,28 @@
       "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.6.1.tgz",
       "integrity": "sha1-4PyVEztu8nbNyIh82vJKpvFW+Po="
     },
-    "lru-cache": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.3.tgz",
-      "integrity": "sha512-fFEhvcgzuIoJVUF8fYr5KR0YqxD238zgObTps31YdADwPPAp82a4M8TrckkWyx7ekNlf9aBcVn81cFwwXngrJA==",
+    "make-error": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.5.tgz",
+      "integrity": "sha512-c3sIjNUow0+8swNwVpqoH4YCShKNFkMaw6oH1mNS2haDZQqkeZFlHS3dhoeEbKKmJB4vXpJucU6oH75aDYeE9g==",
+      "dev": true
+    },
+    "map-age-cleaner": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/map-age-cleaner/-/map-age-cleaner-0.1.2.tgz",
+      "integrity": "sha512-UN1dNocxQq44IhJyMI4TU8phc2m9BddacHRPRjKGLYaF0jqd3xLz0jS0skpAU9WgYyoR4gHtUpzytNBS385FWQ==",
       "requires": {
-        "pseudomap": "^1.0.2",
-        "yallist": "^2.1.2"
-      },
-      "dependencies": {
-        "yallist": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
-          "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
-        }
+        "p-defer": "1.0.0"
       }
     },
     "mem": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/mem/-/mem-1.1.0.tgz",
-      "integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/mem/-/mem-4.0.0.tgz",
+      "integrity": "sha512-WQxG/5xYc3tMbYLXoXPm81ET2WDULiU5FxbuIoNbJqLOOI8zehXFdZuiUEgfdrU2mVB1pxBZUGlYORSrpuJreA==",
       "requires": {
-        "mimic-fn": "^1.0.0"
+        "map-age-cleaner": "0.1.2",
+        "mimic-fn": "1.2.0",
+        "p-is-promise": "1.1.0"
       }
     },
     "mime-db": {
@@ -540,7 +560,7 @@
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.20.tgz",
       "integrity": "sha512-HrkrPaP9vGuWbLK1B1FfgAkbqNjIuy4eHlIYnFi7kamZyLLrGlo2mpcx0bBmNpKqBtYtAfGbodDddIgddSJC2A==",
       "requires": {
-        "mime-db": "~1.36.0"
+        "mime-db": "1.36.0"
       }
     },
     "mimic-fn": {
@@ -553,7 +573,7 @@
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
       "requires": {
-        "brace-expansion": "^1.1.7"
+        "brace-expansion": "1.1.11"
       }
     },
     "minimist": {
@@ -566,8 +586,8 @@
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.3.4.tgz",
       "integrity": "sha512-mlouk1OHlaUE8Odt1drMtG1bAJA4ZA6B/ehysgV0LUIrDHdKgo1KorZq3pK0b/7Z7LJIQ12MNM6aC+Tn6lUZ5w==",
       "requires": {
-        "safe-buffer": "^5.1.2",
-        "yallist": "^3.0.0"
+        "safe-buffer": "5.1.2",
+        "yallist": "3.0.2"
       }
     },
     "minizlib": {
@@ -575,7 +595,7 @@
       "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.1.0.tgz",
       "integrity": "sha512-4T6Ur/GctZ27nHfpt9THOdRZNgyJ9FZchYO1ceg5S8Q3DNLCKYy44nCZzgCJgcvx2UM8czmqak5BCxJMrq37lA==",
       "requires": {
-        "minipass": "^2.2.1"
+        "minipass": "2.3.4"
       }
     },
     "mkdirp": {
@@ -586,12 +606,17 @@
         "minimist": "0.0.8"
       }
     },
+    "nice-try": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
+      "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ=="
+    },
     "npm-run-path": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
       "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
       "requires": {
-        "path-key": "^2.0.0"
+        "path-key": "2.0.1"
       }
     },
     "number-is-nan": {
@@ -609,17 +634,17 @@
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "requires": {
-        "wrappy": "1"
+        "wrappy": "1.0.2"
       }
     },
     "os-locale": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz",
-      "integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-3.0.1.tgz",
+      "integrity": "sha512-7g5e7dmXPtzcP4bgsZ8ixDVqA7oWYuEz4lOSujeWyliPai4gfVDiFIcwBg3aGCPnmSGfzOKTK3ccPn0CKv3DBw==",
       "requires": {
-        "execa": "^0.7.0",
-        "lcid": "^1.0.0",
-        "mem": "^1.1.0"
+        "execa": "0.10.0",
+        "lcid": "2.0.0",
+        "mem": "4.0.0"
       }
     },
     "os-tmpdir": {
@@ -627,17 +652,27 @@
       "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
       "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
     },
+    "p-defer": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-1.0.0.tgz",
+      "integrity": "sha1-n26xgvbJqozXQwBKfU+WsZaw+ww="
+    },
     "p-finally": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
       "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4="
+    },
+    "p-is-promise": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/p-is-promise/-/p-is-promise-1.1.0.tgz",
+      "integrity": "sha1-nJRWmJ6fZYgBewQ01WCXZ1w9oF4="
     },
     "p-limit": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.0.0.tgz",
       "integrity": "sha512-fl5s52lI5ahKCernzzIyAP0QAZbGIovtVHGwpcu1Jr/EpzLVDI2myISHwGqK7m8uQFugVWSrbxH7XnhGtvEc+A==",
       "requires": {
-        "p-try": "^2.0.0"
+        "p-try": "2.0.0"
       }
     },
     "p-locate": {
@@ -645,7 +680,7 @@
       "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
       "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
       "requires": {
-        "p-limit": "^2.0.0"
+        "p-limit": "2.0.0"
       }
     },
     "p-try": {
@@ -683,11 +718,6 @@
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
       "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M="
     },
-    "pseudomap": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
-      "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
-    },
     "psl": {
       "version": "1.1.29",
       "resolved": "https://registry.npmjs.org/psl/-/psl-1.1.29.tgz",
@@ -708,12 +738,12 @@
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
       "integrity": "sha1-j5A0HmilPMySh4jaz80Rs265t44=",
       "requires": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.1",
-        "isarray": "~1.0.0",
-        "process-nextick-args": "~1.0.6",
-        "string_decoder": "~0.10.x",
-        "util-deprecate": "~1.0.1"
+        "core-util-is": "1.0.2",
+        "inherits": "2.0.3",
+        "isarray": "1.0.0",
+        "process-nextick-args": "1.0.7",
+        "string_decoder": "0.10.31",
+        "util-deprecate": "1.0.2"
       }
     },
     "request": {
@@ -721,26 +751,26 @@
       "resolved": "https://registry.npmjs.org/request/-/request-2.88.0.tgz",
       "integrity": "sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==",
       "requires": {
-        "aws-sign2": "~0.7.0",
-        "aws4": "^1.8.0",
-        "caseless": "~0.12.0",
-        "combined-stream": "~1.0.6",
-        "extend": "~3.0.2",
-        "forever-agent": "~0.6.1",
-        "form-data": "~2.3.2",
-        "har-validator": "~5.1.0",
-        "http-signature": "~1.2.0",
-        "is-typedarray": "~1.0.0",
-        "isstream": "~0.1.2",
-        "json-stringify-safe": "~5.0.1",
-        "mime-types": "~2.1.19",
-        "oauth-sign": "~0.9.0",
-        "performance-now": "^2.1.0",
-        "qs": "~6.5.2",
-        "safe-buffer": "^5.1.2",
-        "tough-cookie": "~2.4.3",
-        "tunnel-agent": "^0.6.0",
-        "uuid": "^3.3.2"
+        "aws-sign2": "0.7.0",
+        "aws4": "1.8.0",
+        "caseless": "0.12.0",
+        "combined-stream": "1.0.6",
+        "extend": "3.0.2",
+        "forever-agent": "0.6.1",
+        "form-data": "2.3.2",
+        "har-validator": "5.1.0",
+        "http-signature": "1.2.0",
+        "is-typedarray": "1.0.0",
+        "isstream": "0.1.2",
+        "json-stringify-safe": "5.0.1",
+        "mime-types": "2.1.20",
+        "oauth-sign": "0.9.0",
+        "performance-now": "2.1.0",
+        "qs": "6.5.2",
+        "safe-buffer": "5.1.2",
+        "tough-cookie": "2.4.3",
+        "tunnel-agent": "0.6.0",
+        "uuid": "3.3.2"
       }
     },
     "require-directory": {
@@ -758,7 +788,7 @@
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
       "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
       "requires": {
-        "glob": "^7.0.5"
+        "glob": "7.1.3"
       }
     },
     "safe-buffer": {
@@ -781,10 +811,10 @@
       "resolved": "https://registry.npmjs.org/selenium-webdriver/-/selenium-webdriver-4.0.0-alpha.1.tgz",
       "integrity": "sha512-z88rdjHAv3jmTZ7KSGUkTvo4rGzcDGMq0oXWHNIDK96Gs31JKVdu9+FMtT4KBrVoibg8dUicJDok6GnqqttO5Q==",
       "requires": {
-        "jszip": "^3.1.3",
-        "rimraf": "^2.5.4",
+        "jszip": "3.1.5",
+        "rimraf": "2.6.2",
         "tmp": "0.0.30",
-        "xml2js": "^0.4.17"
+        "xml2js": "0.4.19"
       }
     },
     "semver": {
@@ -802,7 +832,7 @@
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
       "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
       "requires": {
-        "shebang-regex": "^1.0.0"
+        "shebang-regex": "1.0.0"
       }
     },
     "shebang-regex": {
@@ -815,20 +845,36 @@
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
       "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
     },
+    "source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true
+    },
+    "source-map-support": {
+      "version": "0.5.9",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.9.tgz",
+      "integrity": "sha512-gR6Rw4MvUlYy83vP0vxoVNzM6t8MUXqNuRsuBmBHQDu1Fh6X015FrLdgoDKcNdkwGubozq0P4N0Q37UyFVr1EA==",
+      "dev": true,
+      "requires": {
+        "buffer-from": "1.1.1",
+        "source-map": "0.6.1"
+      }
+    },
     "sshpk": {
       "version": "1.14.2",
       "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.14.2.tgz",
       "integrity": "sha1-xvxhZIo9nE52T9P8306hBeSSupg=",
       "requires": {
-        "asn1": "~0.2.3",
-        "assert-plus": "^1.0.0",
-        "bcrypt-pbkdf": "^1.0.0",
-        "dashdash": "^1.12.0",
-        "ecc-jsbn": "~0.1.1",
-        "getpass": "^0.1.1",
-        "jsbn": "~0.1.0",
-        "safer-buffer": "^2.0.2",
-        "tweetnacl": "~0.14.0"
+        "asn1": "0.2.4",
+        "assert-plus": "1.0.0",
+        "bcrypt-pbkdf": "1.0.2",
+        "dashdash": "1.14.1",
+        "ecc-jsbn": "0.1.2",
+        "getpass": "0.1.7",
+        "jsbn": "0.1.1",
+        "safer-buffer": "2.1.2",
+        "tweetnacl": "0.14.5"
       }
     },
     "string-width": {
@@ -836,8 +882,8 @@
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
       "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
       "requires": {
-        "is-fullwidth-code-point": "^2.0.0",
-        "strip-ansi": "^4.0.0"
+        "is-fullwidth-code-point": "2.0.0",
+        "strip-ansi": "4.0.0"
       }
     },
     "string_decoder": {
@@ -850,7 +896,7 @@
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
       "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
       "requires": {
-        "ansi-regex": "^3.0.0"
+        "ansi-regex": "3.0.0"
       }
     },
     "strip-eof": {
@@ -863,13 +909,13 @@
       "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.6.tgz",
       "integrity": "sha512-tMkTnh9EdzxyfW+6GK6fCahagXsnYk6kE6S9Gr9pjVdys769+laCTbodXDhPAjzVtEBazRgP0gYqOjnk9dQzLg==",
       "requires": {
-        "chownr": "^1.0.1",
-        "fs-minipass": "^1.2.5",
-        "minipass": "^2.3.3",
-        "minizlib": "^1.1.0",
-        "mkdirp": "^0.5.0",
-        "safe-buffer": "^5.1.2",
-        "yallist": "^3.0.2"
+        "chownr": "1.1.1",
+        "fs-minipass": "1.2.5",
+        "minipass": "2.3.4",
+        "minizlib": "1.1.0",
+        "mkdirp": "0.5.1",
+        "safe-buffer": "5.1.2",
+        "yallist": "3.0.2"
       }
     },
     "tmp": {
@@ -877,7 +923,7 @@
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.30.tgz",
       "integrity": "sha1-ckGdSovn1s51FI/YsyTlk6cRwu0=",
       "requires": {
-        "os-tmpdir": "~1.0.1"
+        "os-tmpdir": "1.0.2"
       }
     },
     "tough-cookie": {
@@ -885,8 +931,32 @@
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
       "integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
       "requires": {
-        "psl": "^1.1.24",
-        "punycode": "^1.4.1"
+        "psl": "1.1.29",
+        "punycode": "1.4.1"
+      }
+    },
+    "ts-node": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-7.0.1.tgz",
+      "integrity": "sha512-BVwVbPJRspzNh2yfslyT1PSbl5uIk03EZlb493RKHN4qej/D06n1cEhjlOJG69oFsE7OT8XjpTUcYf6pKTLMhw==",
+      "dev": true,
+      "requires": {
+        "arrify": "1.0.1",
+        "buffer-from": "1.1.1",
+        "diff": "3.5.0",
+        "make-error": "1.3.5",
+        "minimist": "1.2.0",
+        "mkdirp": "0.5.1",
+        "source-map-support": "0.5.9",
+        "yn": "2.0.0"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "dev": true
+        }
       }
     },
     "tunnel-agent": {
@@ -894,7 +964,7 @@
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
       "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
       "requires": {
-        "safe-buffer": "^5.0.1"
+        "safe-buffer": "5.1.2"
       }
     },
     "tweetnacl": {
@@ -924,23 +994,23 @@
       "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
       "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
       "requires": {
-        "assert-plus": "^1.0.0",
+        "assert-plus": "1.0.0",
         "core-util-is": "1.0.2",
-        "extsprintf": "^1.2.0"
+        "extsprintf": "1.3.0"
       }
     },
     "webdriver-manager-replacement": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/webdriver-manager-replacement/-/webdriver-manager-replacement-0.5.1.tgz",
-      "integrity": "sha512-F7OKo++IUkjw6CV78Fn2wLQ0H0uMCdX1cUd9hQi5iAU+1zPqJdC03MEVbf8XXGOBKcBovZ8Vs4KqSbHL7x35bA==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/webdriver-manager-replacement/-/webdriver-manager-replacement-1.0.1.tgz",
+      "integrity": "sha512-9Z8hJR5rkyPgtX9HXWc/neZg9iPtwXkwHStVwwUQQwKSF3Yn5K+zxCllp46e5PsjNpfpfg7ufkLqc475mTEQug==",
       "requires": {
-        "adm-zip": "^0.4.11",
-        "loglevel": "^1.6.1",
-        "request": "^2.87.0",
-        "semver": "^5.5.0",
-        "tar": "^4.4.4",
-        "xml2js": "^0.4.19",
-        "yargs": "^12.0.1"
+        "adm-zip": "0.4.11",
+        "loglevel": "1.6.1",
+        "request": "2.88.0",
+        "semver": "5.5.1",
+        "tar": "4.4.6",
+        "xml2js": "0.4.19",
+        "yargs": "12.0.2"
       }
     },
     "which": {
@@ -948,7 +1018,7 @@
       "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
       "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
       "requires": {
-        "isexe": "^2.0.0"
+        "isexe": "2.0.0"
       }
     },
     "which-module": {
@@ -958,11 +1028,11 @@
     },
     "wrap-ansi": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+      "resolved": "http://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
       "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
       "requires": {
-        "string-width": "^1.0.1",
-        "strip-ansi": "^3.0.1"
+        "string-width": "1.0.2",
+        "strip-ansi": "3.0.1"
       },
       "dependencies": {
         "ansi-regex": {
@@ -975,7 +1045,7 @@
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "requires": {
-            "number-is-nan": "^1.0.0"
+            "number-is-nan": "1.0.1"
           }
         },
         "string-width": {
@@ -983,9 +1053,9 @@
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "requires": {
-            "code-point-at": "^1.0.0",
-            "is-fullwidth-code-point": "^1.0.0",
-            "strip-ansi": "^3.0.0"
+            "code-point-at": "1.1.0",
+            "is-fullwidth-code-point": "1.0.0",
+            "strip-ansi": "3.0.1"
           }
         },
         "strip-ansi": {
@@ -993,7 +1063,7 @@
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "requires": {
-            "ansi-regex": "^2.0.0"
+            "ansi-regex": "2.1.1"
           }
         }
       }
@@ -1008,8 +1078,8 @@
       "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.19.tgz",
       "integrity": "sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==",
       "requires": {
-        "sax": ">=0.6.0",
-        "xmlbuilder": "~9.0.1"
+        "sax": "1.2.4",
+        "xmlbuilder": "9.0.7"
       }
     },
     "xmlbuilder": {
@@ -1033,22 +1103,22 @@
       "integrity": "sha1-hFK0u36Dx8GI2AQcGoN8dz1ti7k="
     },
     "yargs": {
-      "version": "12.0.1",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-12.0.1.tgz",
-      "integrity": "sha512-B0vRAp1hRX4jgIOWFtjfNjd9OA9RWYZ6tqGA9/I/IrTMsxmKvtWy+ersM+jzpQqbC3YfLzeABPdeTgcJ9eu1qQ==",
+      "version": "12.0.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-12.0.2.tgz",
+      "integrity": "sha512-e7SkEx6N6SIZ5c5H22RTZae61qtn3PYUE8JYbBFlK9sYmh3DMQ6E5ygtaG/2BW0JZi4WGgTR2IV5ChqlqrDGVQ==",
       "requires": {
-        "cliui": "^4.0.0",
-        "decamelize": "^2.0.0",
-        "find-up": "^3.0.0",
-        "get-caller-file": "^1.0.1",
-        "os-locale": "^2.0.0",
-        "require-directory": "^2.1.1",
-        "require-main-filename": "^1.0.1",
-        "set-blocking": "^2.0.0",
-        "string-width": "^2.0.0",
-        "which-module": "^2.0.0",
-        "y18n": "^3.2.1 || ^4.0.0",
-        "yargs-parser": "^10.1.0"
+        "cliui": "4.1.0",
+        "decamelize": "2.0.0",
+        "find-up": "3.0.0",
+        "get-caller-file": "1.0.3",
+        "os-locale": "3.0.1",
+        "require-directory": "2.1.1",
+        "require-main-filename": "1.0.1",
+        "set-blocking": "2.0.0",
+        "string-width": "2.1.1",
+        "which-module": "2.0.0",
+        "y18n": "4.0.0",
+        "yargs-parser": "10.1.0"
       }
     },
     "yargs-parser": {
@@ -1056,8 +1126,14 @@
       "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-10.1.0.tgz",
       "integrity": "sha512-VCIyR1wJoEBZUqk5PA+oOBF6ypbwh5aNB3I50guxAL/quggdfs4TtNHQrSazFA3fYZ+tEqfs0zIGlv0c/rgjbQ==",
       "requires": {
-        "camelcase": "^4.1.0"
+        "camelcase": "4.1.0"
       }
+    },
+    "yn": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-2.0.0.tgz",
+      "integrity": "sha1-5a2ryKz0CPY4X8dklWhMiOavaJo=",
+      "dev": true
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "index.js",
   "scripts": {
     "http-server": "tsc && node dist/spec/server/http_server.js",
+    "test": "npm run test-unit && npm run test-types && npm run test-int",
     "test-int": "tsc && jasmine JASMINE_CONFIG_PATH=spec/jasmine-int.json",
     "test-types": "tsc && jasmine JASMINE_CONFIG_PATH=spec/jasmine-types.json",
     "test-unit": "tsc && jasmine JASMINE_CONFIG_PATH=spec/jasmine-unit.json",
@@ -24,7 +25,7 @@
   "dependencies": {
     "loglevel": "^1.6.1",
     "selenium-webdriver": "^4.0.0-alpha.1",
-    "webdriver-manager-replacement": "^0.5.1"
+    "webdriver-manager-replacement": "^1.0.1"
   },
   "devDependencies": {
     "@types/jasmine": "^2.8.8",
@@ -34,6 +35,7 @@
     "@types/selenium-webdriver": "^3.0.10",
     "jasmine": "^3.2.0",
     "request": "^2.88.0",
+    "ts-node": "^7.0.1",
     "typescript": "^3.0.3"
   }
 }

--- a/spec/jasmine-int.json
+++ b/spec/jasmine-int.json
@@ -3,6 +3,9 @@
   "spec_files": [
     "**/*.spec-int.js"
   ],
+  "helpers": [
+    "**/helper/wdm_update.js"
+  ],
   "stopSpecOnExpectationFailure": false,
   "random": false
 }

--- a/spec/jasmine-unit.json
+++ b/spec/jasmine-unit.json
@@ -3,6 +3,9 @@
   "spec_files": [
     "**/*.spec-unit.js"
   ],
+  "helpers": [
+    "**/helper/wdm_update.js"
+  ],
   "stopSpecOnExpectationFailure": false,
   "random": true
 }

--- a/spec/server/http_server.ts
+++ b/spec/server/http_server.ts
@@ -5,6 +5,7 @@ import * as url from 'url';
 
 import * as env from './env';
 
+process.setMaxListeners(20);
 const port = process.argv[2] || env.httpPort;
 
 http.createServer(

--- a/spec/support/helper/wdm_update.ts
+++ b/spec/support/helper/wdm_update.ts
@@ -1,0 +1,17 @@
+import * as os from 'os';
+import * as path from 'path';
+import * as wdm from 'webdriver-manager-replacement';
+
+
+const tempDir = path.resolve(os.tmpdir(), 'test');
+export const options: wdm.Options = {
+  browserDrivers: [{name: 'chromedriver'}],
+  server: {
+    name: 'selenium',
+    runAsDetach: true,
+    runAsNode: true
+  },
+  outDir: tempDir
+};
+
+wdm.update(options).then(() => {});


### PR DESCRIPTION
- Implement a way to use directConnect via webdriver-manager's APIs.
- Create interface for browser configuration to pass directConnect as an
option.
- Remove boilerplate code into helper functions.
- Use direct connect in integration tests when possible.

closes #21