### PR TITLE
feat(browser): use the outDir as a browser config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ jobs:
   build:
     working_directory: ~/workspace
     docker:
-      - image: circleci/node:8-browsers
+      - image: circleci/node:9-browsers
     steps:
       - checkout
 
@@ -11,6 +11,8 @@ jobs:
       - run: npm --version
 
       - run: npm install
+      - run: npm run tsc
+      - run: npm run wdm-update
       - run: npm run test-types
       - run: npm run test-unit
       - run: npm run test-int

--- a/lib/browser/browser.ts
+++ b/lib/browser/browser.ts
@@ -4,7 +4,6 @@ import {DirectConnect} from './driver_provider';
 import {wait} from '../wait';
 
 export class Browser {
-  seleniumAddress = 'http://127.0.0.1:4444/wd/hub';
   driver: WebDriver;
   session: Session;
 
@@ -53,8 +52,9 @@ export class Browser {
     if (this.browserConfig.directConnect) {
       this.driver = DirectConnect.getDriver(this.browserConfig);
     } else {
+      // TODO(cnishina): remove this use something from driver_provider
       const builder = new Builder()
-        .usingServer(this.seleniumAddress)
+        .usingServer(this.browserConfig.seleniumAddress)
         .withCapabilities(this.browserConfig.capabilities);
       this.driver = await builder.build();
     }

--- a/lib/browser/browser_config.ts
+++ b/lib/browser/browser_config.ts
@@ -1,6 +1,8 @@
 export interface BrowserConfig {
   capabilities?: Capabilities,
   directConnect?: boolean,
+  outDir?: string,
+  seleniumAddress?: string,
 }
 
 export interface Capabilities {

--- a/lib/browser/driver_provider/direct_connect.ts
+++ b/lib/browser/driver_provider/direct_connect.ts
@@ -11,13 +11,14 @@ export class DirectConnect {
   // TODO(cnsihina): What if the out_dir is different?
   static getDriver(browserConfig: BrowserConfig): WebDriver {
     let driver: WebDriver;
+    const outDir = browserConfig.outDir;
     if (browserConfig.capabilities.browserName === 'chrome') {
-      const chromeDriverPath = new wdm.ChromeDriver().getBinaryPath();
+      const chromeDriverPath = new wdm.ChromeDriver({outDir}).getBinaryPath();
       driver = ChromeDriver.createSession(
         new Capabilities(browserConfig.capabilities),
         new ChromeServiceBuilder(chromeDriverPath).build());
     } else if (browserConfig.capabilities.browserName === 'firefox') {
-      const geckoDriverPath = new wdm.GeckoDriver().getBinaryPath();
+      const geckoDriverPath = new wdm.GeckoDriver({outDir}).getBinaryPath();
       driver = FirefoxDriver.createSession(
         new Capabilities(browserConfig.capabilities),
         new FirefoxServiceBuilder(geckoDriverPath).build());

--- a/lib/browser/driver_provider/index.ts
+++ b/lib/browser/driver_provider/index.ts
@@ -1,1 +1,2 @@
 export * from './direct_connect';
+export * from './local';

--- a/lib/browser/driver_provider/local.spec-int.ts
+++ b/lib/browser/driver_provider/local.spec-int.ts
@@ -1,0 +1,43 @@
+import * as net from 'net';
+import {Local} from './local';
+
+describe('local', () => {
+  const origTimeout = jasmine.DEFAULT_TIMEOUT_INTERVAL;
+  beforeAll(() => {
+    jasmine.DEFAULT_TIMEOUT_INTERVAL = 20000;
+  });
+
+  afterAll(() => {
+    jasmine.DEFAULT_TIMEOUT_INTERVAL = origTimeout;
+  });
+
+  describe('class Local', () => {
+    describe('findPort', () => {
+      let server4000: net.Server;
+      let server4001: net.Server;
+      let server4002: net.Server;
+
+      beforeAll(() => {
+        server4000 = net.createServer().listen(4000);
+        server4001 = net.createServer().listen(4001);
+        server4002 = net.createServer().listen(4002);
+      });
+
+      afterAll(() => {
+        server4000.close();
+        server4001.close();
+        server4002.close();
+      });
+
+      it('should find a port greater than 4002', async () => {
+        const port = await Local.findPort(4000, 4500);
+        expect(port).toBeGreaterThanOrEqual(4002);
+      });
+
+      it('should not find a port', async () => {
+        const port = await Local.findPort(4000, 4002);
+        expect(port).toBeNull();
+      });
+    });
+  });
+});

--- a/lib/browser/driver_provider/local.ts
+++ b/lib/browser/driver_provider/local.ts
@@ -1,5 +1,6 @@
-import * as wdm from 'webdriver-manager-replacement';
 import * as loglevel from 'loglevel';
+import * as net from 'net';
+import * as wdm from 'webdriver-manager-replacement';
 import {Capabilities, WebDriver} from 'selenium-webdriver';
 import {Driver as ChromeDriver, ServiceBuilder as ChromeServiceBuilder} from 'selenium-webdriver/chrome';
 import {Driver as FirefoxDriver, ServiceBuilder as FirefoxServiceBuilder} from 'selenium-webdriver/firefox';
@@ -12,11 +13,32 @@ export class Local {
     // how will we pass the port to wdm?
   }
 
-  static findPort() {
-    // try to create a selenium server on an open port.
-    // keep a range of 4000 - 50000
-
-    // start servers at the port, if they encounter a 
-    // EADDRINUSE or EACCES, move on.
+  /**
+   * Find the port number.
+   * @param portRangeStart
+   * @param portRangeEnd
+   */
+  static async findPort(
+      portRangeStart: number, portRangeEnd: number): Promise<number> {
+    let portFound = null;
+    for (let port = portRangeStart; port <= portRangeEnd; port++) {
+      let server: net.Server;
+      const portAvailable = await new Promise<boolean>(resolve => {
+        server = net.createServer().listen(port)
+          .on('error', () => {
+            // EADDRINUSE or EACCES, move on.
+            resolve(false);
+          })
+          .on('listening', () => {
+            resolve(true);
+          });
+      });
+      server.close();
+      if (portAvailable) {
+        portFound = port;
+        break;
+      }
+    }
+    return portFound;
   }
 }

--- a/lib/element/all/element_array_finder.spec-int.ts
+++ b/lib/element/all/element_array_finder.spec-int.ts
@@ -14,7 +14,7 @@ describe('element_array_finder', () => {
   const capabilities = {
     browserName: 'chrome',
     chromeOptions: {
-      args: ['--headless', '--disable-gpu']
+      args: ['--headless', '--disable-gpu', '--noSandbox']
     }
   };
   let browser: Browser;

--- a/lib/element/element_finder.spec-int.ts
+++ b/lib/element/element_finder.spec-int.ts
@@ -15,7 +15,7 @@ describe('element_finder', () => {
   const capabilities = {
     browserName: 'chrome',
     chromeOptions: {
-      args: ['--headless', '--disable-gpu']
+      args: ['--headless', '--disable-gpu', '--noSandbox']
     },
   };
   let browser: Browser;

--- a/lib/element/index.spec-int.ts
+++ b/lib/element/index.spec-int.ts
@@ -15,7 +15,7 @@ describe('index', () => {
   const capabilities = {
     browserName: 'chrome',
     chromeOptions: {
-      args: ['--headless', '--disable-gpu']
+      args: ['--headless', '--disable-gpu', '--noSandbox']
     },
   };
   let browser: Browser;

--- a/lib/protractor.spec-int.ts
+++ b/lib/protractor.spec-int.ts
@@ -10,7 +10,7 @@ log.setLevel('info');
 const capabilities = {
   browserName: 'chrome',
   chromeOptions: {
-    args: ['--headless']
+    args: ['--headless', '--disable-gpu', '--noSandbox']
   },
 };
 const config = {capabilities, directConnect: true};

--- a/package-lock.json
+++ b/package-lock.json
@@ -1028,7 +1028,7 @@
     },
     "wrap-ansi": {
       "version": "2.1.0",
-      "resolved": "http://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
       "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
       "requires": {
         "string-width": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "test-types": "tsc && jasmine JASMINE_CONFIG_PATH=spec/jasmine-types.json",
     "test-unit": "tsc && jasmine JASMINE_CONFIG_PATH=spec/jasmine-unit.json",
     "tsc": "tsc",
-    "wdm": "webdriver-manager-replacement"
+    "wdm": "webdriver-manager-replacement",
+    "wdm-update": "webdriver-manager-replacement update --gecko=false"
   },
   "repository": {
     "type": "git",

--- a/spec/jasmine-int.json
+++ b/spec/jasmine-int.json
@@ -1,11 +1,9 @@
 {
-  "spec_dir": "dist",
+  "spec_dir": "dist/",
   "spec_files": [
     "**/*.spec-int.js"
   ],
-  "helpers": [
-    "**/helper/wdm_update.js"
-  ],
+  "helpers": [],
   "stopSpecOnExpectationFailure": false,
   "random": false
 }

--- a/spec/jasmine-unit.json
+++ b/spec/jasmine-unit.json
@@ -3,9 +3,6 @@
   "spec_files": [
     "**/*.spec-unit.js"
   ],
-  "helpers": [
-    "**/helper/wdm_update.js"
-  ],
   "stopSpecOnExpectationFailure": false,
   "random": true
 }

--- a/spec/support/wdm_options.ts
+++ b/spec/support/wdm_options.ts
@@ -1,17 +1,11 @@
-import * as os from 'os';
-import * as path from 'path';
 import * as wdm from 'webdriver-manager-replacement';
 
-
-const tempDir = path.resolve(os.tmpdir(), 'test');
 export const options: wdm.Options = {
   browserDrivers: [{name: 'chromedriver'}],
   server: {
     name: 'selenium',
+    port: 4444,
     runAsDetach: true,
     runAsNode: true
-  },
-  outDir: tempDir
+  }
 };
-
-wdm.update(options).then(() => {});


### PR DESCRIPTION
- Update the browser config to have an outDir. The outDir will be used
by the browser to find the correct file.
- Use outDir specified in the spec/support/helper/wdm_update.
- Add a way to find an open port in preparation to start the selenium
server on a random port range.

closes #28