### PR TITLE
feat(drivers): add providers for hosted and local.

### DIFF
--- a/lib/browser/browser.spec-int.ts
+++ b/lib/browser/browser.spec-int.ts
@@ -32,8 +32,7 @@ describe('browser', () => {
     beforeAll(async() => {
       await wdm.start(options);
       seleniumAddress = 'http://127.0.0.1:4444/wd/hub';
-      browser = new Browser({capabilities,
-        seleniumAddress});
+      browser = new Browser({capabilities, seleniumAddress});
       wdSessions = seleniumAddress + '/sessions';
       await new Promise((resolve, _) => {
         log.info('sleeping for 10 seconds');

--- a/lib/browser/browser_config.ts
+++ b/lib/browser/browser_config.ts
@@ -1,11 +1,25 @@
 export interface BrowserConfig {
-  capabilities?: Capabilities,
-  directConnect?: boolean,
-  outDir?: string,
-  seleniumAddress?: string,
+  capabilities?: Capabilities;
+
+  /* The output directory where webdriver-manager saves the binaries. */
+  outDir?: string;
+
+  /* direct connect: connect directly to a browser driver. */
+  directConnect?: boolean;
+
+  /* hosted: Selenium address example: http://127.0.0.1:4444/wd/hub */
+  seleniumAddress?: string;
+
+  /* local: The starting port range. */
+  portRangeStart?: number;
+
+  /* local: The end port range. */
+  portRangeEnd?: number;
 }
 
 export interface Capabilities {
   [key: string]: any;
+
+  /* The browser name. */
   browserName?: string;
 }

--- a/lib/browser/driver_provider/README.md
+++ b/lib/browser/driver_provider/README.md
@@ -1,0 +1,19 @@
+# Driver Providers
+
+The driver provider defines a way that Protractor will connect to WebDriver.
+Below are the list of driver providers:
+
+- **direct connect**: Directly run with a browser driver binary. The supported
+browsers include firefox and chrome. Direct connect relies on passing the
+`directConnect` boolean via the browser config and will launch with the driver
+provider based on the capabilities `browserName`. The binaries required be
+downloaded via webdriver-manager.
+- **hosted**: The selenium server standalone is already running. Passing the
+`seleniumAddress` string via the browser config. The value usually is
+'http://127.0.0.1:4444/wd/hub'. No binaries are required since the server is
+already running.
+- **local**: When launching locally, this will find a port on a range and
+launch the selenium standalone server. It will start the server with binaries
+downloaded by webdriver-manager. It must have a minimum of the selenium jar
+and one of the browser binaries. This does not check to see if the capabilities
+match up.

--- a/lib/browser/driver_provider/direct_connect.spec-unit.ts
+++ b/lib/browser/driver_provider/direct_connect.spec-unit.ts
@@ -3,18 +3,9 @@ import {DirectConnect} from './direct_connect';
 describe('direct_connect', () => {
   describe('DirectConnect', () => {
     describe('getDriver', () => {
-      it('should create a chrome driver', () => {
+      it('should create a chromedriver', async () => {
         const browserConfig = {capabilities: {browserName: 'chrome'}};
-        const driver = DirectConnect.getDriver(browserConfig);
-        expect(driver).not.toBeNull();
-        expect(driver.constructor.name).toBe('Driver');
-      });
-    });
-
-    describe('getDriver', () => {
-      it('should create a chrome driver', () => {
-        const browserConfig = {capabilities: {browserName: 'chrome'}};
-        const driver = DirectConnect.getDriver(browserConfig);
+        const driver = await new DirectConnect(browserConfig).getDriver();
         expect(driver).not.toBeNull();
         expect(driver.constructor.name).toBe('Driver');
       });

--- a/lib/browser/driver_provider/direct_connect.ts
+++ b/lib/browser/driver_provider/direct_connect.ts
@@ -4,29 +4,44 @@ import {Capabilities, WebDriver} from 'selenium-webdriver';
 import {Driver as ChromeDriver, ServiceBuilder as ChromeServiceBuilder} from 'selenium-webdriver/chrome';
 import {Driver as FirefoxDriver, ServiceBuilder as FirefoxServiceBuilder} from 'selenium-webdriver/firefox';
 import {BrowserConfig} from '../browser_config';
+import {Provider} from './provider';
 
 const log = loglevel.getLogger('protractor');
 
-export class DirectConnect {
-  // TODO(cnsihina): What if the out_dir is different?
-  static getDriver(browserConfig: BrowserConfig): WebDriver {
+export class DirectConnect implements Provider {
+  constructor(public browserConfig: BrowserConfig) {}
+
+  /**
+   * Gets the driver generated from directly connecting to the browser driver.
+   * @returns A promise for the WebDriver.
+   */
+  async getDriver(): Promise<WebDriver> {
     let driver: WebDriver;
-    const outDir = browserConfig.outDir;
-    if (browserConfig.capabilities.browserName === 'chrome') {
+    const outDir = this.browserConfig.outDir;
+    if (this.browserConfig.capabilities.browserName === 'chrome') {
       const chromeDriverPath = new wdm.ChromeDriver({outDir}).getBinaryPath();
       driver = ChromeDriver.createSession(
-        new Capabilities(browserConfig.capabilities),
+        new Capabilities(this.browserConfig.capabilities),
         new ChromeServiceBuilder(chromeDriverPath).build());
-    } else if (browserConfig.capabilities.browserName === 'firefox') {
+    } else if (this.browserConfig.capabilities.browserName === 'firefox') {
       const geckoDriverPath = new wdm.GeckoDriver({outDir}).getBinaryPath();
       driver = FirefoxDriver.createSession(
-        new Capabilities(browserConfig.capabilities),
+        new Capabilities(this.browserConfig.capabilities),
         new FirefoxServiceBuilder(geckoDriverPath).build());
     } else {
       log.warn('Browser provided is not supported.')
       log.warn('Supported browsers: chrome and firefox');
     }
-    return driver;
+    return Promise.resolve(driver);
+  }
+
+  /**
+   * Quits the driver generated from directly connecting to the browser driver.
+   * This is a no-op.
+   * @returns A promise.
+   */
+  async quitDriver():Promise<void> {
+    return Promise.resolve();
   }
 }
 

--- a/lib/browser/driver_provider/hosted.spec-int.ts
+++ b/lib/browser/driver_provider/hosted.spec-int.ts
@@ -1,0 +1,48 @@
+import {Hosted} from './hosted';
+import * as wdm from 'webdriver-manager-replacement';
+
+const options: wdm.Options = {
+  browserDrivers: [{name: 'chromedriver'}],
+  server: {
+    name: 'selenium',
+    runAsDetach: true,
+    runAsNode: true
+  }
+};
+
+describe('hosted', () => {
+  const origTimeout = jasmine.DEFAULT_TIMEOUT_INTERVAL;
+  beforeAll(() => {
+    jasmine.DEFAULT_TIMEOUT_INTERVAL = 20000;
+  });
+
+  afterAll(() => {
+    jasmine.DEFAULT_TIMEOUT_INTERVAL = origTimeout;
+  });
+
+  describe('class Hosted', () => {
+    beforeAll(async () => {
+      await wdm.start(options);
+    });
+
+    afterAll(async () => {
+      await wdm.shutdown(options);
+    });
+
+    describe('getDriver', () => {
+      it('should create a driver using seleniumAddress', async () => {
+        const capabilities = {
+          browserName: 'chrome',
+          chromeOptions: {
+            args: ['--headless', '--disable-gpu', '--noSandbox']
+          },
+        };
+        const browserConfig = {capabilities,
+          seleniumAddress: 'http://127.0.0.1:4444/wd/hub'};
+        const driver = await new Hosted(browserConfig).getDriver();
+        expect(driver).not.toBeNull();
+        expect(driver.constructor.name).toBe('mixin');
+      });
+    });
+  });
+});

--- a/lib/browser/driver_provider/hosted.ts
+++ b/lib/browser/driver_provider/hosted.ts
@@ -1,0 +1,27 @@
+import {BrowserConfig} from '../browser_config';
+import {Builder, WebDriver} from 'selenium-webdriver';
+import {Provider} from './provider';
+
+export class Hosted implements Provider {
+  constructor(public browserConfig: BrowserConfig) {}
+
+  /**
+   * Gets the driver generated when the selenium address is available.
+   * @returns A promise for the WebDriver.
+   */
+  async getDriver(): Promise<WebDriver> {
+    const builder = new Builder()
+      .usingServer(this.browserConfig.seleniumAddress)
+      .withCapabilities(this.browserConfig.capabilities);
+    return builder.build();
+  }
+
+  /**
+   * Quits the driver generated from directly connecting to the browser driver.
+   * This is a no-op.
+   * @returns A promise.
+   */
+  async quitDriver() {
+    return Promise.resolve();
+  }
+}

--- a/lib/browser/driver_provider/index.ts
+++ b/lib/browser/driver_provider/index.ts
@@ -1,2 +1,4 @@
 export * from './direct_connect';
+export * from './hosted';
 export * from './local';
+export * from './provider';

--- a/lib/browser/driver_provider/local.spec-int.ts
+++ b/lib/browser/driver_provider/local.spec-int.ts
@@ -12,6 +12,24 @@ describe('local', () => {
   });
 
   describe('class Local', () => {
+    describe('getDriver', () => {
+      it('should create a selenium server and a driver', async () => {
+        const capabilities = {
+          browserName: 'chrome',
+          chromeOptions: {
+            args: ['--headless', '--disable-gpu', '--noSandbox']
+          },
+        };
+        const browserConfig = {capabilities, portRangeStart: 5000,
+          portRangeEnd: 6000};
+        const local = new Local(browserConfig);
+        const driver = await local.getDriver();
+        expect(driver).not.toBeNull();
+        expect(driver.constructor.name).toBe('mixin');
+        await local.quitDriver();
+      });
+    });
+
     describe('findPort', () => {
       let server4000: net.Server;
       let server4001: net.Server;
@@ -30,12 +48,14 @@ describe('local', () => {
       });
 
       it('should find a port greater than 4002', async () => {
-        const port = await Local.findPort(4000, 4500);
+        const local = new Local({});
+        const port = await local.findPort(4000, 4500);
         expect(port).toBeGreaterThanOrEqual(4002);
       });
 
       it('should not find a port', async () => {
-        const port = await Local.findPort(4000, 4002);
+        const local = new Local({});
+        const port = await local.findPort(4000, 4002);
         expect(port).toBeNull();
       });
     });

--- a/lib/browser/driver_provider/local.ts
+++ b/lib/browser/driver_provider/local.ts
@@ -1,29 +1,102 @@
-import * as loglevel from 'loglevel';
 import * as net from 'net';
 import * as wdm from 'webdriver-manager-replacement';
-import {Capabilities, WebDriver} from 'selenium-webdriver';
-import {Driver as ChromeDriver, ServiceBuilder as ChromeServiceBuilder} from 'selenium-webdriver/chrome';
-import {Driver as FirefoxDriver, ServiceBuilder as FirefoxServiceBuilder} from 'selenium-webdriver/firefox';
+import {Builder, WebDriver} from 'selenium-webdriver';
 import {BrowserConfig} from '../browser_config';
+import {Provider} from './provider';
 
-const log = loglevel.getLogger('protractor');
+export class Local implements Provider {
+  options: wdm.Options;
+  constructor(public browserConfig: BrowserConfig) {
+    // Generate the options for webdriver-manager to start the selenium server.
+    this.options = {
+      browserDrivers: [],
+    };
 
-export class Local {
-  static getDriver() {
-    // how will we pass the port to wdm?
+    if (new wdm.SeleniumServer().getBinaryPath()) {
+      this.options.server = {
+        name: 'selenium',
+        runAsDetach: true,
+        runAsNode: true
+      };
+    } else {
+      throw new Error('No selenium server jar file.');
+    }
+    if (new wdm.ChromeDriver().getBinaryPath()) {
+      this.options.browserDrivers.push({name: 'chromedriver'});
+    }
+    if (new wdm.GeckoDriver().getBinaryPath()) {
+      this.options.browserDrivers.push({name: 'geckodriver'});
+    }
+    if (new wdm.IEDriver().getBinaryPath()) {
+      this.options.browserDrivers.push({name: 'iedriver'});
+    }
+    if (this.options.browserDrivers.length === 0) {
+      throw new Error('No browser drivers were found.');
+    }
   }
 
   /**
-   * Find the port number.
+   * Starts the selenium server standalone on an available port range. After
+   * starting the server, it will build the driver.
+   * @returns A promise for the WebDriver.
+   */
+  async getDriver(): Promise<WebDriver> {
+    const port = await this.findPort(
+      this.browserConfig.portRangeStart, this.browserConfig.portRangeEnd);
+    const seleniumAddress = `http://127.0.0.1:${port}/wd/hub`;
+    this.options.server.port = port;
+
+    await wdm.start(this.options);
+
+    // TODO(cnishina): A event listener on SIGNIT to quit the driver. This will
+    // be a good clean up step to not leave any selenium servers running in the
+    // background.
+
+    const builder = new Builder()
+      .usingServer(seleniumAddress)
+      .withCapabilities(this.browserConfig.capabilities);
+    return await builder.build();
+  }
+
+  /**
+   * Shutsdown the selenium server standalone. If this is not called after
+   * the test ends, the java command will still run in the background.
+   */
+  async quitDriver(): Promise<void> {
+    await wdm.shutdown(this.options);
+  }
+
+  /**
+   * Find the port number that is available for the port range provided.
+   * Assumes that the portRangeStart < portRangeEnd and that the portRangeEnd
+   * should also be checked.
    * @param portRangeStart
    * @param portRangeEnd
    */
-  static async findPort(
+  async findPort(
       portRangeStart: number, portRangeEnd: number): Promise<number> {
+    
+    // When no start is provided but an end range is provided, create
+    // an arbitrary start point.
+    if (!portRangeStart && portRangeEnd) {
+      portRangeStart = portRangeEnd - 1000;
+    }
+    // When no end is provided but a start range is provided, create
+    // an arbitrary end point.
+    if (portRangeStart && !portRangeEnd) {
+      portRangeEnd = portRangeStart + 1000;
+    }
+    // If no start and end are provided, create a range from 4000 to 5000.
+    if (!portRangeStart && !portRangeEnd) {
+      portRangeStart = 4000;
+      portRangeEnd = 5000;
+    }
+    
     let portFound = null;
     for (let port = portRangeStart; port <= portRangeEnd; port++) {
       let server: net.Server;
-      const portAvailable = await new Promise<boolean>(resolve => {
+      let shouldBreak = await new Promise<boolean>(resolve => {
+        // Start a server to check if we can listen to a port.
         server = net.createServer().listen(port)
           .on('error', () => {
             // EADDRINUSE or EACCES, move on.
@@ -32,10 +105,15 @@ export class Local {
           .on('listening', () => {
             resolve(true);
           });
+      }).then(result => {
+        if (result) {
+          // If the server is listening, close the server.
+          server.close();
+          portFound = port;
+        }
+        return result;
       });
-      server.close();
-      if (portAvailable) {
-        portFound = port;
+      if (shouldBreak) {
         break;
       }
     }

--- a/lib/browser/driver_provider/provider.ts
+++ b/lib/browser/driver_provider/provider.ts
@@ -1,0 +1,13 @@
+import {WebDriver} from 'selenium-webdriver';
+
+/**
+ * Generic interface for driver providers.
+ */
+export interface Provider {
+
+  /* Gets the webdriver object. */
+  getDriver(): Promise<WebDriver>;
+
+  /* Quits the driver. */
+  quitDriver(): Promise<void>;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1000,9 +1000,9 @@
       }
     },
     "webdriver-manager-replacement": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/webdriver-manager-replacement/-/webdriver-manager-replacement-1.0.1.tgz",
-      "integrity": "sha512-9Z8hJR5rkyPgtX9HXWc/neZg9iPtwXkwHStVwwUQQwKSF3Yn5K+zxCllp46e5PsjNpfpfg7ufkLqc475mTEQug==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/webdriver-manager-replacement/-/webdriver-manager-replacement-1.1.0.tgz",
+      "integrity": "sha512-f+P7hV4pjIEkOTjRsXlQYjRQhWKZz2pjgRhqlNv2I3Jkjo35LXf+QanDXRgwv7u093NZzdV6dcuhxtbFyYhPEg==",
       "requires": {
         "adm-zip": "0.4.11",
         "loglevel": "1.6.1",
@@ -1028,7 +1028,7 @@
     },
     "wrap-ansi": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+      "resolved": "http://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
       "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
       "requires": {
         "string-width": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "dependencies": {
     "loglevel": "^1.6.1",
     "selenium-webdriver": "^4.0.0-alpha.1",
-    "webdriver-manager-replacement": "^1.0.1"
+    "webdriver-manager-replacement": "^1.1.0"
   },
   "devDependencies": {
     "@types/jasmine": "^2.8.8",


### PR DESCRIPTION
- local - should launch a selenium server standalone with webdriver-manager on an available port.
- hosted - should launch a driver with an available selenium server
standalone.
- add readme docs for driver providers.

closes #26