### PR TITLE
chore(element): getDriver, findElement, and locator

### DIFF
--- a/lib/core/browser/browser.ts
+++ b/lib/core/browser/browser.ts
@@ -8,18 +8,23 @@ const ACTION_OPTIONS: ActionOptions = {
 };
 
 export class Browser {
-  driver: WebDriver;
-  session: Session;
+  private _driver: WebDriver;
+  private _session: Session;
 
-  constructor(public browserConfig?: BrowserConfig) {
-    const httpClient = new HttpClient(this.browserConfig.seleniumAddress);
+  constructor(private _browserConfig?: BrowserConfig) {
+    const httpClient = new HttpClient(this._browserConfig.seleniumAddress);
     const executor = new Executor(httpClient);
-    const session = new Session(this.browserConfig.seleniumSessionId, null);
-    this.driver = new WebDriver(session, executor);
+    this._session = new Session(this._browserConfig.seleniumSessionId, null);
+    this._driver = new WebDriver(this._session, executor);
   }
 
-  async execute<T>(func: string|Function, ...args): Promise<T> {
-    return await this.driver.executeScript(func) as T;
+  /**
+   * Executes the script and returns the result as T.
+   * @param func The function represented as a string or a function.
+   * @param args Arguments for the func.
+   */
+  async execute<T>(func: string|Function, ...args: any[]): Promise<T> {
+    return await this._driver.executeScript(func, args) as T;
   }
 
   /**
@@ -30,9 +35,17 @@ export class Browser {
   async get(url: string,
       actionOptions: ActionOptions = ACTION_OPTIONS): Promise<void> {
     const action = async (): Promise<void> => {
-      await this.driver.get(url);
+      await this._driver.get(url);
     };
-    return runAction(action, actionOptions, this);
+    return runAction(action, actionOptions, this._driver);
+  }
+
+  /**
+   * Returns the WebDriver running the session.
+   * @return The WebDriver object.
+   */
+  get driver(): WebDriver {
+    return this._driver;
   }
 
   /**
@@ -42,9 +55,9 @@ export class Browser {
   async getCurrentUrl(
       actionOptions: ActionOptions = ACTION_OPTIONS): Promise<string> {
     const action = async (): Promise<string> => {
-      return await this.driver.getCurrentUrl();
+      return await this._driver.getCurrentUrl();
     };
-    return runAction(action, actionOptions, this);
+    return runAction(action, actionOptions, this._driver);
   }
 
   /**
@@ -54,15 +67,15 @@ export class Browser {
   async getTitle(
       actionOptions: ActionOptions = ACTION_OPTIONS): Promise<string> {
     const action = async (): Promise<string> => {
-      return await this.driver.getTitle();
+      return await this._driver.getTitle();
     };
-    return runAction(action, actionOptions, this);
+    return runAction(action, actionOptions, this._driver);
   }
 
   /**
    * Quits this browser session.
    */
   async quit(): Promise<void> {
-    await this.driver.quit();
+    await this._driver.quit();
   }
 }

--- a/lib/core/by/locator.ts
+++ b/lib/core/by/locator.ts
@@ -9,8 +9,8 @@ export type WebDriverLocator = wdBy | ByHash | Function;
  * Protractor's location strategy.
  */
 export interface ProtractorLocator {
-  findElementsOverride:
-      (driver: WebDriver, using: WebElement) => Promise<WebElement[]>;
+  findElementsOverride: (driver: WebDriver|WebElement,
+      using: WebElement) => Promise<WebElement[]>;
   row?: (index: number) => Locator;
   column?: (index: string) => Locator;
   toString?: () => string;

--- a/lib/core/element/element_finder.int-spec.ts
+++ b/lib/core/element/element_finder.int-spec.ts
@@ -49,7 +49,8 @@ describe('element_finder', () => {
 
   describe('elementFinderFactory', () => {
     it('should create a an elementFinder object', () => {
-      const elementFinder = elementFinderFactory(browser, By.css('.foo'));
+      const elementFinder = elementFinderFactory(
+        browser.driver, By.css('.foo'));
       expect(elementFinder).not.toBeNull();
       expect(elementFinder.constructor.name).toBe('ElementFinder');
     });
@@ -59,9 +60,9 @@ describe('element_finder', () => {
     describe('clear', () => {
       it('should clear the input', async () => {
         const inputEmpty = elementFinderFactory(
-          browser, By.css('.input-empty'));
+          browser.driver, By.css('.input-empty'));
         const inputValue = elementFinderFactory(
-          browser, By.css('.input-value'));
+          browser.driver, By.css('.input-value'));
         await browser.get(page1);
         await inputEmpty.clear();
         await inputValue.clear();
@@ -73,7 +74,7 @@ describe('element_finder', () => {
     describe('click', () => {
       it('should click a link', async () => {
         const navPage2 = elementFinderFactory(
-          browser, By.css('.nav-page2'));
+          browser.driver, By.css('.nav-page2'));
         await browser.get(page1);
         await navPage2.click();
         let currentUrl = await browser.getCurrentUrl();
@@ -84,9 +85,9 @@ describe('element_finder', () => {
     describe('getAttribute', () => {
       it('should get the contents from the input tag', async () => {
         const inputEmpty = elementFinderFactory(
-          browser, By.css('.input-empty'));
+          browser.driver, By.css('.input-empty'));
         const inputValue = elementFinderFactory(
-          browser, By.css('.input-value'));
+          browser.driver, By.css('.input-value'));
         await browser.get(page1);
         expect(await inputEmpty.getAttribute('value')).toBe('');
         expect(await inputValue.getAttribute('value')).toBe('foobar');
@@ -96,7 +97,7 @@ describe('element_finder', () => {
     describe('getText', () => {
       it('should get the contents of the html tag', async () => {
         const navPage2 = elementFinderFactory(
-          browser, By.css('.nav-page2'));
+          browser.driver, By.css('.nav-page2'));
         await browser.get(page1);
         expect(await navPage2.getText()).toBe('nav to page2');
       });
@@ -105,9 +106,9 @@ describe('element_finder', () => {
     describe('isDisplayed', () => {
       it('should check if the spans are visible', async () => {
         const spanHidden = elementFinderFactory(
-          browser, By.css('.span-hidden'));
+          browser.driver, By.css('.span-hidden'));
         const spanVisible = elementFinderFactory(
-          browser, By.css('.span-visible'));
+          browser.driver, By.css('.span-visible'));
         await browser.get(page1);
         expect(await spanHidden.isDisplayed()).toBeFalsy();
         expect(await spanVisible.isDisplayed()).toBeTruthy();
@@ -117,9 +118,9 @@ describe('element_finder', () => {
     describe('isEnabled', () => {
       it('should check if the buttons are enabled', async () => {
         const buttonDisabled = elementFinderFactory(
-          browser, By.css('.button-disabled'));
+          browser.driver, By.css('.button-disabled'));
         const buttonEnabled = elementFinderFactory(
-          browser, By.css('.button-enabled'));
+          browser.driver, By.css('.button-enabled'));
         await browser.get(page1);
         expect(await buttonDisabled.isEnabled()).toBeFalsy();
         expect(await buttonEnabled.isEnabled()).toBeTruthy();
@@ -129,9 +130,9 @@ describe('element_finder', () => {
     describe('isSelected', () => {
       it('should check if the checkboxes are selected', async () => {
         const checkboxNotSelected = elementFinderFactory(
-          browser, By.css('.checkbox-not-selected'));
+          browser.driver, By.css('.checkbox-not-selected'));
         const checkboxSelected = elementFinderFactory(
-          browser, By.css('.checkbox-selected'));
+          browser.driver, By.css('.checkbox-selected'));
         await browser.get(page1);
         expect(await checkboxNotSelected.isSelected()).toBeFalsy();
         expect(await checkboxSelected.isSelected()).toBeTruthy();
@@ -141,7 +142,7 @@ describe('element_finder', () => {
     describe('sendKeys', () => {
       it('should get the contents of the html tag', async () => {
         const inputEmpty = elementFinderFactory(
-          browser, By.css('.input-empty'));
+          browser.driver, By.css('.input-empty'));
         await browser.get(page1);
         await inputEmpty.sendKeys('foo bar baz');
         let value = await inputEmpty.getAttribute('value');

--- a/lib/core/element/element_finder.unit-spec.ts
+++ b/lib/core/element/element_finder.unit-spec.ts
@@ -12,7 +12,8 @@ describe('element_finder', () => {
         seleniumAddress: 'http://127.0.0.1:4444/wd/hub',
         seleniumSessionId: '12345'
       });
-      const elementFinder = elementFinderFactory(browser, By.css('.foo'));
+      const elementFinder = elementFinderFactory(
+        browser.driver, By.css('.foo'));
       expect(elementFinder).not.toBeNull();
       expect(elementFinder.constructor.name).toBe('ElementFinder');
     });

--- a/lib/core/element/index.ts
+++ b/lib/core/element/index.ts
@@ -28,7 +28,7 @@ export interface ElementHelper extends Function {
  */
 export function buildElementHelper(browser: Browser): ElementHelper {
   let element: ElementHelper = (locator: Locator): ElementFinder => {
-    return elementFinderFactory(browser, locator);
+    return elementFinderFactory(browser.driver, locator);
   }
   element['all'] = (locator: Locator): ElementArrayFinder => {
     return elementArrayFinderFactory(browser, locator);


### PR DESCRIPTION
- Finding element searching within the webElement or the webDriver (browser instance) required refactoring the elementFinderFactory.
- Set the browser variables to private with a getter for the driver.