### PR TITLE
chore(element.all): set properties to private

### DIFF
--- a/lib/core/element/all/element_array_finder.int-spec.ts
+++ b/lib/core/element/all/element_array_finder.int-spec.ts
@@ -48,7 +48,7 @@ describe('element_array_finder', () => {
   describe('elementArrayFinderFactory', () => {
     it('should create a an elementArrayFinder object', () => {
       let elementArrayFinder = elementArrayFinderFactory(
-        browser, By.css('.foo'));
+        browser.driver, By.css('.foo'));
       expect(elementArrayFinder).not.toBeNull();
       expect(elementArrayFinder.constructor.name).toBe('ElementArrayFinder');
     });
@@ -57,7 +57,7 @@ describe('element_array_finder', () => {
   describe('ElementArrayFinder', () => {
     it('should find a list of web elements', async () => {
       let elementArrayFinder = elementArrayFinderFactory(
-        browser, By.css('.nav-page1'));
+        browser.driver, By.css('.nav-page1'));
       await browser.get(page2);
       let webElements = await elementArrayFinder.getWebElements();
       expect(webElements.length).toBe(5);

--- a/lib/core/element/all/element_array_finder.ts
+++ b/lib/core/element/all/element_array_finder.ts
@@ -1,25 +1,42 @@
-import { WebElement } from 'selenium-webdriver';
+import { WebDriver, WebElement } from 'selenium-webdriver';
 import { Browser } from '../../browser';
 import { GetWebElements } from '../get_web_elements';
 import { isProtractorLocator, Locator } from '../../by/locator';
 
 export function elementArrayFinderFactory(
-    browser: Browser,
+    driver: WebDriver|WebElement,
     locator: Locator): ElementArrayFinder {
   let getWebElements: GetWebElements = async (): Promise<WebElement[]> => {
     if (isProtractorLocator(locator)) {
-      return locator.findElementsOverride(browser.driver, null);
+      return locator.findElementsOverride(driver, null);
     } else {
-      return browser.driver.findElements(locator);
+      return driver.findElements(locator);
     }
   }
-  return new ElementArrayFinder(browser, locator, getWebElements);
+  return new ElementArrayFinder(driver, locator, getWebElements);
 }
 
 export class ElementArrayFinder {
   constructor(
-    public browser: Browser,
-    public locator: Locator,
+    private _driver: WebDriver|WebElement,
+    private _locator: Locator,
     public getWebElements: GetWebElements) {
+  }
+
+  /**
+   * Gets the parent driver.
+   * @return The WebDriver parent object.
+   */
+  async getDriver(): Promise<WebDriver> {
+    const webElements = await this.getWebElements();
+    return webElements[0].getDriver();
+  }
+
+  /**
+   * Gets the locator strategy.
+   * @return The locator object.
+   */
+  get locator(): Locator {
+    return this._locator;
   }
 }

--- a/lib/core/element/all/element_array_finder.unit-spec.ts
+++ b/lib/core/element/all/element_array_finder.unit-spec.ts
@@ -13,7 +13,7 @@ describe('element_array_finder', () => {
         seleniumSessionId: '12345'
       }); 
       const elementArrayFinder = elementArrayFinderFactory(
-        browser, By.css('.foo'));
+        browser.driver, By.css('.foo'));
       expect(elementArrayFinder).not.toBeNull();
       expect(elementArrayFinder.constructor.name).toBe('ElementArrayFinder');
     });

--- a/lib/core/element/element_finder.ts
+++ b/lib/core/element/element_finder.ts
@@ -244,7 +244,7 @@ export class ElementFinder {
    * Gets the locator strategy.
    * @return The locator object.
    */
-  locator(): Locator {
+  get locator(): Locator {
     return this._locator;
   }
 

--- a/lib/core/element/index.ts
+++ b/lib/core/element/index.ts
@@ -31,7 +31,7 @@ export function buildElementHelper(browser: Browser): ElementHelper {
     return elementFinderFactory(browser.driver, locator);
   }
   element['all'] = (locator: Locator): ElementArrayFinder => {
-    return elementArrayFinderFactory(browser, locator);
+    return elementArrayFinderFactory(browser.driver, locator);
   }
   return element;
 }

--- a/lib/core/index.ts
+++ b/lib/core/index.ts
@@ -2,6 +2,8 @@ import { Browser, BrowserConfig } from './browser';
 import { By } from './by';
 import { buildElementHelper } from './element';
 
+export { BrowserConfig } from './browser';
+
 /**
  * Builds the objects for protractor that use the same selenium browser session.
  * @param config A configuration object with a capabilities property.


### PR DESCRIPTION
- Set ElementArrayFinder to use WebDriver or WebElement instead of
browser.
- Change locator from method to getter property.
- Export browser config in index.