### PR TITLE
chore(tasks): use protected task options and shared results

### DIFF
--- a/lib/core/element/element_finder.ts
+++ b/lib/core/element/element_finder.ts
@@ -3,7 +3,7 @@ import { GetWebElements } from './get_web_elements';
 import { Element } from './';
 import { elementArrayFinderFactory, ElementArrayFinder } from './all';
 import { isProtractorLocator, Locator } from '../by/locator';
-import { Rectangle, runAction, SharedResults, TaskOptions } from '../utils';
+import { Rectangle, runAction, SharedResults, sharedResultsInit, TaskOptions, taskOptionsInit } from '../utils';
 
 export function elementFinderFactory(
     driver: WebDriver|WebElement|Promise<WebDriver|WebElement>,
@@ -19,60 +19,55 @@ export function elementFinderFactory(
   return new ElementFinder(driver, locator, getWebElements);
 }
 
-const SHARED_RESULTS: SharedResults = {};
-const TASK_OPTIONS: TaskOptions = {
-  retries: 1
-};
-
 export class ElementFinder {
-
+  protected _taskOptions: TaskOptions;
+  protected _sharedResults: SharedResults;
   constructor(
-    private _driver: WebDriver|WebElement|Promise<WebDriver|WebElement>,
-    private _locator: Locator,
-    private _getWebElements: GetWebElements) {
+    protected _driver: WebDriver|WebElement|Promise<WebDriver|WebElement>,
+    protected _locator: Locator,
+    protected _getWebElements: GetWebElements) {
   }
 
   /**
    * Clears the text from an input or textarea web element.
-   * @param taskOptions Optional options for retries and functionHooks.
-   * @param sharedResults Optional shared results to help debugging.
    * @return A promise to this object.
    */
-  async clear(taskOptions: TaskOptions = TASK_OPTIONS,
-      sharedResults: SharedResults = SHARED_RESULTS): Promise<ElementFinder> {
+  async clear(): Promise<ElementFinder> {
+    this._sharedResults = sharedResultsInit();
+    this._taskOptions = taskOptionsInit();
     const action = async (): Promise<void> => {
       const webElement = await this.getWebElement();
       await webElement.clear();
     };
-    await runAction(action, taskOptions, sharedResults, this._driver);
+    await runAction(action, this._taskOptions,
+      this._sharedResults, this._driver);
     return this;
   }
 
   /**
    * Clicks on a web element.
-   * @param taskOptions Optional options for retries and functionHooks.
-   * @param sharedResults Optional shared results to help debugging.
    * @return A promise to this object.
    */
-  async click(taskOptions: TaskOptions = TASK_OPTIONS,
-      sharedResults: SharedResults = SHARED_RESULTS): Promise<ElementFinder> {
+  async click(): Promise<ElementFinder> {
+    this._sharedResults = sharedResultsInit();
+    this._taskOptions = taskOptionsInit();
     // Gets the first web element matching the locator and clicks on it.
     const action = async (): Promise<void> => {
       const webElement = await this.getWebElement();
       await webElement.click();
     };
-    await runAction(action, taskOptions, sharedResults, this._driver);
+    await runAction(action, this._taskOptions,
+      this._sharedResults, this._driver);
     return this;
   }
 
   /**
    * The count of web elements.
-   * @param taskOptions Optional options for retries and functionHooks.
-   * @param sharedResults Optional shared results to help debugging.
    * @return A promise of the number of elements matching the locator.
    */
-  count(taskOptions: TaskOptions = TASK_OPTIONS,
-      sharedResults: SharedResults = SHARED_RESULTS): Promise<number> {
+  count(): Promise<number> {
+    this._sharedResults = sharedResultsInit();
+    this._taskOptions = taskOptionsInit();
     const action = async(): Promise<number> => {
       try {
         const webElements = await this._getWebElements();
@@ -81,19 +76,18 @@ export class ElementFinder {
         throw err;
       }
     };
-    return runAction(action, taskOptions, sharedResults, this._driver);
+    return runAction(action, this._taskOptions,
+      this._sharedResults, this._driver);
   }
 
   /**
    * Compares an element to this one for equality.
    * @param webElement The element to compare to.
-   * @param taskOptions Optional options for retries and functionHooks.
-   * @param sharedResults Optional shared results to help debugging.
    * @return A promise that will be resolved if they are equal.
    */
-  async equals(webElement: ElementFinder | WebElement,
-      taskOptions: TaskOptions = TASK_OPTIONS,
-      sharedResults: SharedResults = SHARED_RESULTS): Promise<boolean> {
+  async equals(webElement: ElementFinder | WebElement): Promise<boolean> {
+    this._sharedResults = sharedResultsInit();
+    this._taskOptions = taskOptionsInit();
     const action = async (): Promise<boolean> => {
       const a = await this.getWebElement();
       const b = (webElement['getWebElement']) ?
@@ -104,7 +98,8 @@ export class ElementFinder {
       return driver.executeScript<boolean>(
         'return arguments[0] === arguments[1]', a, b);
     };
-    return runAction(action, taskOptions, sharedResults, this._driver);
+    return runAction(action, this._taskOptions,
+      this._sharedResults, this._driver);
   }
 
   private buildElement(
@@ -122,9 +117,7 @@ export class ElementFinder {
           return (await awaitedDriver).findElements(locator);
         }
       }
-      
-      return new ElementFinder(
-        getDriver(), locator, getWebElements);
+      return new ElementFinder(getDriver(), locator, getWebElements);
     }
     element['all'] = (locator: Locator): ElementArrayFinder => {
       return elementArrayFinderFactory(driver, locator);
@@ -138,14 +131,13 @@ export class ElementFinder {
    * Creates an ElementFinder from either the WebDriver or within a WebElement.
    * @param driver The WebDriver or WebElement object.
    * @param locator The locator strategy.
-   * @param taskOptions Optional options for retries and functionHooks.
-   * @param sharedResults Optional shared results to help debugging.
    * @return The ElementFinder object.
    */
   static async fromWebElement(
       driver: WebDriver|WebElement|Promise<WebDriver|WebElement>,
-      locator: Locator, taskOptions: TaskOptions = TASK_OPTIONS,
-      sharedResults: SharedResults = SHARED_RESULTS): Promise<ElementFinder> {
+      locator: Locator): Promise<ElementFinder> {
+    let sharedResults = sharedResultsInit();
+    let taskOptions = taskOptionsInit();
     const action = async(): Promise<ElementFinder> => {
       const getWebElements = async (): Promise<WebElement[]> => {
         const awaitedDriver = await driver;
@@ -167,31 +159,31 @@ export class ElementFinder {
    * @param sharedResults Optional shared results to help debugging.
    * @return A promise to the attribute value.
    */
-  getAttribute(attributeName: string,
-      taskOptions: TaskOptions = TASK_OPTIONS,
-      sharedResults: SharedResults = SHARED_RESULTS): Promise<string> {
+  getAttribute(attributeName: string): Promise<string> {
+    this._sharedResults = sharedResultsInit();
+    this._taskOptions = taskOptionsInit();
     const action = async (): Promise<string> => {
       const webElement = await this.getWebElement();
       return webElement.getAttribute(attributeName);
     };
-    return runAction(action, taskOptions, sharedResults, this._driver);
+    return runAction(action, this._taskOptions,
+      this._sharedResults, this._driver);
   }
 
   /**
    * Retrieves the value of a computed style property for this instance.
    * @param cssStyleProperty The name of the CSS style property to look up.
-   * @param taskOptions Optional options for retries and functionHooks.
-   * @param sharedResults Optional shared results to help debugging.
    * @return A promise that will be resolved with the requested CSS value.
    */
-  getCssValue(cssStyleProperty: string,
-      taskOptions: TaskOptions = TASK_OPTIONS,
-      sharedResults: SharedResults = SHARED_RESULTS): Promise<string> {
+  getCssValue(cssStyleProperty: string): Promise<string> {
+    this._sharedResults = sharedResultsInit();
+    this._taskOptions = taskOptionsInit();
     const action = async (): Promise<string> => {
       const webElement = await this.getWebElement();
       return webElement.getCssValue(cssStyleProperty);
     };
-    return runAction(action, taskOptions, sharedResults, this._driver);
+    return runAction(action, this._taskOptions,
+      this._sharedResults, this._driver);
   }
 
   /**
@@ -206,13 +198,19 @@ export class ElementFinder {
    * @param sharedResults Optional shared results to help debugging.
    * @return A rectangle.
    */
-  getRect(taskOptions: TaskOptions = TASK_OPTIONS,
-      sharedResults: SharedResults = SHARED_RESULTS): Promise<Rectangle> {
+  getRect(): Promise<Rectangle> {
+    this._sharedResults = sharedResultsInit();
+    this._taskOptions = taskOptionsInit();
     const action = async (): Promise<Rectangle> => {
       const webElement = await this.getWebElement();
       return (webElement as any).getRect();
     }
-    return runAction(action, taskOptions, sharedResults, this._driver);
+    return runAction(action, this._taskOptions,
+      this._sharedResults, this._driver);
+  }
+
+  get sharedResults(): SharedResults {
+    return this._sharedResults;
   }
 
   /**
@@ -222,32 +220,32 @@ export class ElementFinder {
 
   /**
    * Gets the tag name of the web element.
-   * @param taskOptions Optional options for retries and functionHooks.
-   * @param sharedResults Optional shared results to help debugging.
    * @return A promise to the tag name.
    */
-  getTagName(taskOptions: TaskOptions = TASK_OPTIONS,
-      sharedResults: SharedResults = SHARED_RESULTS): Promise<string> {
+  getTagName(): Promise<string> {
+    this._sharedResults = sharedResultsInit();
+    this._taskOptions = taskOptionsInit();
     const action = async (): Promise<string> => {
       const webElement = await this.getWebElement();
       return webElement.getTagName();
     };
-    return runAction(action, taskOptions, sharedResults, this._driver);
+    return runAction(action, this._taskOptions,
+      this._sharedResults, this._driver);
   }
 
   /**
    * Gets the text contents from the html tag.
-   * @param taskOptions Optional options for retries and functionHooks.
-   * @param sharedResults Optional shared results to help debugging.
    * @return A promise to the text.
    */
-  getText(taskOptions: TaskOptions = TASK_OPTIONS,
-      sharedResults: SharedResults = SHARED_RESULTS): Promise<string> {
+  getText(): Promise<string> {
+    this._sharedResults = sharedResultsInit();
+    this._taskOptions = taskOptionsInit();
     const action = async (): Promise<string> => {
       const webElement = await this.getWebElement();
       return webElement.getText();
     };
-    return runAction(action, taskOptions, sharedResults, this._driver);
+    return runAction(action, this._taskOptions,
+      this._sharedResults, this._driver);
   }
 
   /**
@@ -262,17 +260,17 @@ export class ElementFinder {
 
   /**
    * Whether the element is displayed.
-   * @param taskOptions Optional options for retries and functionHooks.
-   * @param sharedResults Optional shared results to help debugging.
    * @return A promise if the web element is displayed.
    */
-  isDisplayed(taskOptions: TaskOptions = TASK_OPTIONS,
-      sharedResults: SharedResults = SHARED_RESULTS): Promise<boolean> {
+  isDisplayed(): Promise<boolean> {
+    this._sharedResults = sharedResultsInit();
+    this._taskOptions = taskOptionsInit();
     const action = async (): Promise<boolean> => {
       const webElement = await this.getWebElement();
       return webElement.isDisplayed();
     };
-    return runAction(action, taskOptions, sharedResults, this._driver);
+    return runAction(action, this._taskOptions,
+      this._sharedResults, this._driver);
   }
 
   /**
@@ -282,28 +280,27 @@ export class ElementFinder {
 
   /**
    * Whether the web element is enabled.
-   * @param taskOptions Optional options for retries and functionHooks.
-   * @param sharedResults Optional shared results to help debugging.
    * @return A promise if the web element is enabled.
    */
-  isEnabled(taskOptions: TaskOptions = TASK_OPTIONS,
-      sharedResults: SharedResults = SHARED_RESULTS): Promise<boolean> {
+  isEnabled(): Promise<boolean> {
+    this._sharedResults = sharedResultsInit();
+    this._taskOptions = taskOptionsInit();
     const action = async (): Promise<boolean> => {
       const webElement = await this.getWebElement();
       return webElement.isEnabled();
     };
-    return runAction(action, taskOptions, sharedResults, this._driver);
+    return runAction(action, this._taskOptions,
+      this._sharedResults, this._driver);
   }
 
   /**
    * Checks if the web element is present. If provided with a locatorOrElement,
    * it get the ElementFinder for the locatorOrElement
    * @param locator Opt locator to find a WebElement within this WebElement
-   * @param taskOptions Optional options for retries and functionHooks.
-   * @param sharedResults Optional shared results to help debugging.
    */
-  async isPresent(locator?: Locator, taskOptions: TaskOptions = TASK_OPTIONS,
-      sharedResults: SharedResults = SHARED_RESULTS): Promise<boolean> {
+  async isPresent(locator?: Locator): Promise<boolean> {
+    this._sharedResults = sharedResultsInit();
+    this._taskOptions = taskOptionsInit();
     const action = async (): Promise<boolean> => {
       if (locator) {
         // Get the element if it is within this element and check the count.
@@ -315,7 +312,8 @@ export class ElementFinder {
         return await this.count() >= 1;
       }
     };
-    return runAction(action, taskOptions, sharedResults, this._driver);
+    return runAction(action, this._taskOptions,
+      this._sharedResults, this._driver);
   }
 
   /**
@@ -324,13 +322,15 @@ export class ElementFinder {
    * @param sharedResults Optional shared results to help debugging.
    * @return A promise if the web element is selected.
    */
-  isSelected(taskOptions: TaskOptions = TASK_OPTIONS,
-      sharedResults: SharedResults = SHARED_RESULTS): Promise<boolean> {
+  isSelected(): Promise<boolean> {
+    this._sharedResults = sharedResultsInit();
+    this._taskOptions = taskOptionsInit();
     const action = async (): Promise<boolean> => {
       const webElement = await this.getWebElement();
       return webElement.isSelected();
     };
-    return runAction(action, taskOptions, sharedResults, this._driver);
+    return runAction(action, this._taskOptions,
+      this._sharedResults, this._driver);
   }
 
   /**
@@ -344,33 +344,33 @@ export class ElementFinder {
   /**
    * Send keys to the input field.
    * @param keys
-   * @param taskOptions Optional options for retries and functionHooks.
-   * @param sharedResults Optional shared results to help debugging.
    * @return A promise to this object.
    */
-  async sendKeys(keys: string|number, taskOptions: TaskOptions = TASK_OPTIONS,
-      sharedResults: SharedResults = SHARED_RESULTS): Promise<ElementFinder> {
+  async sendKeys(keys: string|number): Promise<ElementFinder> {
+    this._sharedResults = sharedResultsInit();
+    this._taskOptions = taskOptionsInit();
     const action = async (): Promise<void> => {
       const webElement = await this.getWebElement();
       return webElement.sendKeys(keys);
     };
-    await runAction(action, taskOptions, sharedResults, this._driver);
+    await runAction(action, this._taskOptions,
+      this._sharedResults, this._driver);
     return this;
   }
 
   /**
    * Submits the form containing this element.
-   * @param taskOptions Optional options for retries and functionHooks.
-   * @param sharedResults Optional shared results to help debugging.
    * @return A promise to this object.
    */
-  async submit(taskOptions: TaskOptions = TASK_OPTIONS,
-      sharedResults: SharedResults = SHARED_RESULTS): Promise<ElementFinder> {
+  async submit(): Promise<ElementFinder> {
+    this._sharedResults = sharedResultsInit();
+    this._taskOptions = taskOptionsInit();
     const action = async (): Promise<void> => {
       const webElement = await this.getWebElement();
       return webElement.submit();
     }
-    await runAction(action, taskOptions, sharedResults, this._driver);
+    await runAction(action, this._taskOptions,
+      this._sharedResults, this._driver);
     return this;
   }
 }

--- a/lib/core/utils/shared_results.ts
+++ b/lib/core/utils/shared_results.ts
@@ -1,10 +1,7 @@
 import { Cookie } from './cookie';
 
-export function sharedResultsInit(sharedResults: SharedResults): SharedResults {
-  if (!sharedResults) {
-    sharedResults = {};
-  }
-  return sharedResults;
+export function sharedResultsInit(): SharedResults {
+  return {};
 }
 
 /**

--- a/lib/core/utils/task_options.ts
+++ b/lib/core/utils/task_options.ts
@@ -1,16 +1,13 @@
 /**
  * Since these options is just an interface, initialize objects and create empty
  * arrays.
- * @param taskOptions The task options.
  * @return The initialized task options.
  */
-export function taskOptionsInit(taskOptions: TaskOptions): TaskOptions {
-  if (!taskOptions) {
-    taskOptions = {
-      retries: 1,
-      useDefaults: true,
-      validate: true,
-    };
+export function taskOptionsInit(): TaskOptions {
+  let taskOptions: TaskOptions = {
+    retries: 1,
+    validate: true,
+    useDefaults: true
   }
   if (!taskOptions.tasks) {
     taskOptions.tasks = {};


### PR DESCRIPTION
- set private properties to protected to allow them to be extended.
- use protected task options and shared results.
- remove task options and shared results as parameters in methods.